### PR TITLE
Set evaluate_before_training at beginning if epochs==0

### DIFF
--- a/train.py
+++ b/train.py
@@ -432,6 +432,11 @@ def run(cfg: Any) -> None:
     if cfg.training.epochs >= 0:
         do_run_train = True
 
+    # Force evaluation if user trains 0 epochs
+    cfg.training.evaluate_before_training = (
+        cfg.training.evaluate_before_training or cfg.training.epochs == 0
+    )
+
     # Set the random seed for reproducibility
     # either random seed when user set it -1 or deterministic user chosen seed
     if cfg.environment.seed < 0:
@@ -567,11 +572,6 @@ def run(cfg: Any) -> None:
     if cfg.training.save_best_checkpoint:
         cfg.training.evaluation_epochs = 1
         cfg.training.train_validation_data = False
-
-    # Force evaluation if user trains 0 epochs
-    cfg.training.evaluate_before_training = (
-        cfg.training.evaluate_before_training or cfg.training.epochs == 0
-    )
 
     # reset steps
     cfg.environment._curr_step = 0


### PR DESCRIPTION
If `epochs ==0` and `Evaluate Before Training` is disabled, evaluation epochs are calculated incorrectly (see [here](https://github.com/h2oai/h2o-llmstudio/blob/main/train.py#L525)).

This PR sets  `cfg.training.evaluate_before_training=True` at the beginning of an experiment.
This PR fixes #1.

