### PR TITLE
Chained conversation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,11 @@ During an experiment you can adapt the data representation with the following se
 
 - **Prompt Column:** The column in the dataset containing the user prompt.
 - **Answer Column:** The column in the dataset containing the expected output.
-- **Text Prompt Start:** Text to be added before the user prompt.
-- **Text Answer Separator:** The separator used between the prompt and the answer in the dataset.
-- **Prepend Column Name:** Whether to add the column name to the text input from the left. As an example, if the prompt and answer columns are named "Question" and "Answer" enabling this option would add "Question: " before the question and "Answer: " before the answer. 
-- **Add Eos Token To Answer:** Whether to add an explicit end-of-sequence token at the end of the answer.
+- **Parent Column:** An optional column specifying the parent id to be used for chained conversations. The value of this column needs to match an additional column with the name `id`. If provided, the prompt will be concatenated after preceeding parent rows.
 
 ### Example data:
 We provide an example dataset (converted dataset from [OpenAssistant/oasst1](https://huggingface.co/datasets/OpenAssistant/oasst1))
-that can be downloaded [here](https://www.kaggle.com/code/philippsinger/openassistant-conversations-dataset-oasst1?scriptVersionId=126228752). It is recommended to use `train_full.csv` for training. This dataset is also downloaded and prepared by default when first starting the GUI.
+that can be downloaded [here](https://www.kaggle.com/code/philippsinger/openassistant-conversations-dataset-oasst1?scriptVersionId=127047926). It is recommended to use `train_full.csv` for training. This dataset is also downloaded and prepared by default when first starting the GUI.
 
 ## Training your model
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Using CLI for fine-tuning LLMs:
 [![Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://www.kaggle.com/code/philippsinger/h2o-llm-studio-cli/) [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1-OYccyTvmfa3r7cAquw8sioFFPJcn4R9?usp=sharing)
 
 
+## What's New
+
+- April 25, 2023 Added functionality for supporting nested conversations in data. A new `parent_id_column` can be selected for datasets to support tree-like structures in your conversational data. Additional `augmentation` settings have been added for this feature.
+
+Please note that due to current rapid development we cannot guarantee full backwards compatibility of new functionality. Please either reset your `data` and `output` folders when upgrading and running into compatibility issues.
+
 ## Setup
 H2O LLM Studio requires a machine with Ubuntu 16.04+ and at least one recent Nvidia GPU with Nvidia drivers version >= 470.57.02. For larger models, we recommend at least 24GB of GPU memory.
 
@@ -88,7 +94,7 @@ During an experiment you can adapt the data representation with the following se
 
 - **Prompt Column:** The column in the dataset containing the user prompt.
 - **Answer Column:** The column in the dataset containing the expected output.
-- **Parent Column:** An optional column specifying the parent id to be used for chained conversations. The value of this column needs to match an additional column with the name `id`. If provided, the prompt will be concatenated after preceeding parent rows.
+- **Parent Id Column:** An optional column specifying the parent id to be used for chained conversations. The value of this column needs to match an additional column with the name `id`. If provided, the prompt will be concatenated after preceeding parent rows.
 
 ### Example data:
 We provide an example dataset (converted dataset from [OpenAssistant/oasst1](https://huggingface.co/datasets/OpenAssistant/oasst1))

--- a/app_utils/config.py
+++ b/app_utils/config.py
@@ -64,6 +64,7 @@ default_cfg = {
         "validation_dataframe",
         "prompt_column",
         "answer_column",
+        "parent_column",
     ],
     "dataset_trigger_keys": [
         "train_dataframe",

--- a/app_utils/config.py
+++ b/app_utils/config.py
@@ -64,7 +64,7 @@ default_cfg = {
         "validation_dataframe",
         "prompt_column",
         "answer_column",
-        "parent_column",
+        "parent_id_column",
     ],
     "dataset_trigger_keys": [
         "train_dataframe",

--- a/app_utils/initializers.py
+++ b/app_utils/initializers.py
@@ -48,6 +48,7 @@ def import_data(q: Q):
             cfg.dataset.train_dataframe = os.path.join(path, "train_full.pq")
             cfg.dataset.prompt_column = "instruction"
             cfg.dataset.answer_column = "output"
+            cfg.dataset.parent_id_column = "None"
 
             cfg_path = os.path.join(path, f"{default_cfg.cfg_file}.p")
 

--- a/app_utils/initializers.py
+++ b/app_utils/initializers.py
@@ -36,9 +36,7 @@ def import_data(q: Q):
                 shutil.rmtree(path)
             os.makedirs(path, exist_ok=True)
 
-            df = prepare_default_dataset()
-
-            df.to_csv(os.path.join(path, "train_full.csv"), index=False)
+            df = prepare_default_dataset(path)
 
             cfg = load_config(
                 config_path=os.path.join(
@@ -47,7 +45,7 @@ def import_data(q: Q):
                 config_name="ConfigProblemBase",
             )
 
-            cfg.dataset.train_dataframe = os.path.join(path, "train_full.csv")
+            cfg.dataset.train_dataframe = os.path.join(path, "train_full.pq")
             cfg.dataset.prompt_column = "instruction"
             cfg.dataset.answer_column = "output"
 

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -2046,14 +2046,14 @@ def get_single_gpu_usage(sig_figs=1, highlight=None):
     return items
 
 
-def prepare_default_dataset():
+def prepare_default_dataset(path):
     ds = load_dataset("OpenAssistant/oasst1")
     train = ds["train"].to_pandas()
     val = ds["validation"].to_pandas()
 
     df = pd.concat([train, val], axis=0).reset_index(drop=True)
 
-    df_assistant = df[(df.role == "assistant") & (df["rank"] == 0.0)].copy()
+    df_assistant = df[(df.role == "assistant")].copy()
     df_prompter = df[(df.role == "prompter")].copy()
     df_prompter = df_prompter.set_index("message_id")
     df_assistant["output"] = df_assistant["text"].values
@@ -2068,11 +2068,24 @@ def prepare_default_dataset():
     df_assistant["instruction"] = inputs
     df_assistant["parent_id"] = parent_ids
 
-    df_assistant = df_assistant[df_assistant.lang == "en"]
-
     df_assistant = df_assistant[
-        ["instruction", "output", "message_id", "parent_id"]
+        ["instruction", "output", "message_id", "parent_id", "lang", "rank"]
     ].rename(columns={"message_id": "id"})
 
+    df_assistant[(df_assistant["rank"]==0.0) & (df_assistant["lang"]=="en")][
+        ["instruction", "output", "id", "parent_id"]
+    ].to_parquet(os.path.join(path, "train_full.pq"), index=False)
 
-    return df_assistant
+    df_assistant[df_assistant["lang"]=="en"][
+        ["instruction", "output", "id", "parent_id"]
+    ].to_parquet(os.path.join(path, "train_full_allrank.pq"), index=False)
+
+    df_assistant[df_assistant["rank"]==0.0][
+        ["instruction", "output", "id", "parent_id"]
+    ].to_parquet(os.path.join(path, "train_full_multilang.pq"), index=False)
+    
+    df_assistant[
+        ["instruction", "output", "id", "parent_id"]
+    ].to_parquet(os.path.join(path, "train_full_multilang_allrank.pq"), index=False)
+
+    return df_assistant[(df_assistant["rank"]==0.0) & (df_assistant["lang"]=="en")]

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -2074,4 +2074,5 @@ def prepare_default_dataset():
         ["instruction", "output", "message_id", "parent_id"]
     ].rename(columns={"message_id": "id"})
 
+
     return df_assistant

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -2072,20 +2072,20 @@ def prepare_default_dataset(path):
         ["instruction", "output", "message_id", "parent_id", "lang", "rank"]
     ].rename(columns={"message_id": "id"})
 
-    df_assistant[(df_assistant["rank"]==0.0) & (df_assistant["lang"]=="en")][
+    df_assistant[(df_assistant["rank"] == 0.0) & (df_assistant["lang"] == "en")][
         ["instruction", "output", "id", "parent_id"]
     ].to_parquet(os.path.join(path, "train_full.pq"), index=False)
 
-    df_assistant[df_assistant["lang"]=="en"][
+    df_assistant[df_assistant["lang"] == "en"][
         ["instruction", "output", "id", "parent_id"]
     ].to_parquet(os.path.join(path, "train_full_allrank.pq"), index=False)
 
-    df_assistant[df_assistant["rank"]==0.0][
+    df_assistant[df_assistant["rank"] == 0.0][
         ["instruction", "output", "id", "parent_id"]
     ].to_parquet(os.path.join(path, "train_full_multilang.pq"), index=False)
-    
-    df_assistant[
-        ["instruction", "output", "id", "parent_id"]
-    ].to_parquet(os.path.join(path, "train_full_multilang_allrank.pq"), index=False)
 
-    return df_assistant[(df_assistant["rank"]==0.0) & (df_assistant["lang"]=="en")]
+    df_assistant[["instruction", "output", "id", "parent_id"]].to_parquet(
+        os.path.join(path, "train_full_multilang_allrank.pq"), index=False
+    )
+
+    return df_assistant[(df_assistant["rank"] == 0.0) & (df_assistant["lang"] == "en")]

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -2059,14 +2059,19 @@ def prepare_default_dataset():
     df_assistant["output"] = df_assistant["text"].values
 
     inputs = []
+    parent_ids = []
     for _, row in df_assistant.iterrows():
         input = df_prompter.loc[row.parent_id]
         inputs.append(input.text)
+        parent_ids.append(input.parent_id)
 
     df_assistant["instruction"] = inputs
+    df_assistant["parent_id"] = parent_ids
 
     df_assistant = df_assistant[df_assistant.lang == "en"]
 
-    df_assistant = df_assistant[["instruction", "output"]]
+    df_assistant = df_assistant[
+        ["instruction", "output", "message_id", "parent_id"]
+    ].rename(columns={"message_id": "id"})
 
     return df_assistant

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -19,6 +19,7 @@ It is possible to tune the following parameters:
 - **Max Length Answer:** The maximum sequence length of the answer to use during training.
 - **Max Length:** The maximum sequence length of both prompt and answer to use during training.
 - **Padding Quantile:** Truncates batches to the maximum sequence length based on specified quantile; setting to 0 disables this functionality.
+- **Add Prompt Answer Tokens:** Adds prompt and answer tokens as new tokens to the tokenizer. It is recommended to also set `Force Embedding Gradients` in this case.
 
 ### **Augmentation Parameters**
 - **Token Mask Probability:** The probability of masking each token during training.

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -22,6 +22,8 @@ It is possible to tune the following parameters:
 
 ### **Augmentation Parameters**
 - **Token Mask Probability:** The probability of masking each token during training.
+- **Skip Parent Probability:** If `Parent Column` is set, this random augmentation will skip parent concatenation during training at each parent with this specified probability.
+- **Random Parent Probability:** While training, each sample will be concatenated to a random other sample simulating unrelated chained conversations. Can be specified without using a `Parent Column`.
 
 ### **Architecture Parameters**
 - **Backbone Dtype:** The datatype of the weights in the LLM backbone.

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -239,6 +239,8 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
 
     prompt_column: Tuple[str, ...] = ("instruction", "input")
     answer_column: str = "output"
+    parent_column: str = "None"
+
     text_prompt_start: str = ""
     text_answer_separator: str = "\\n"
 
@@ -268,10 +270,13 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
         self._possible_values["data_sample"] = (0.05, 1, 0.05)
         self._possible_values["data_sample_choice"] = ["Train", "Validation"]
         self._possible_values["prompt_column"] = possible_values.Columns(
-            prefer_with=lambda column: column in ("Instruction", "prompt")
+            prefer_with=lambda column: column in ("instruction", "prompt")
         )
         self._possible_values["answer_column"] = possible_values.Columns(
             prefer_with=lambda column: column in ("answer", "output")
+        )
+        self._possible_values["parent_column"] = possible_values.Columns(
+            prefer_with=lambda column: column in ("parent"), add_none=True
         )
 
         self._nesting.add(
@@ -342,10 +347,12 @@ class ConfigNLPCausalLMArchitecture(DefaultConfig):
 class ConfigNLPAugmentation(DefaultConfig):
     nlp_augmentations_class: Any = BaseNLPAug
     token_mask_probability: float = 0
+    random_parent_sample_probability: float = 0
 
     def __post_init__(self):
         super().__post_init__()
         self._possible_values["token_mask_probability"] = (0, 0.9, 0.05)
+        self._possible_values["random_parent_sample_probability"] = (0, 1.0, 0.05)
         self._visibility["nlp_augmentations_class"] = -1
 
 

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -191,6 +191,7 @@ class ConfigNLPCausalLMTokenizer(DefaultConfig):
     max_length_answer: int = 256
     max_length: int = 512
     padding_quantile: float = 1.0
+    add_prompt_answer_tokens: bool = False
     add_prefix_space: bool = False
 
     def __post_init__(self):

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -35,7 +35,7 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
 
     prompt_column: Tuple[str, ...] = ("instruction", "input")
     answer_column: str = "output"
-    parent_column: str = "None"
+    parent_id_column: str = "None"
 
     text_prompt_start: str = "<|prompt|>"
     text_answer_separator: str = "<|answer|>"
@@ -71,8 +71,8 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
         self._possible_values["answer_column"] = possible_values.Columns(
             prefer_with=lambda column: column in ("answer", "output")
         )
-        self._possible_values["parent_column"] = possible_values.Columns(
-            prefer_with=lambda column: column in ("parent"), add_none=True
+        self._possible_values["parent_id_column"] = possible_values.Columns(
+            prefer_with=lambda column: column in ("parent",), add_none=True
         )
 
         self._nesting.add(

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -21,6 +21,78 @@ from llm_studio.src.utils.modeling_utils import generate_experiment_name
 
 
 @dataclass
+class ConfigNLPCausalLMDataset(DefaultConfig):
+    dataset_class: Any = (
+        llm_studio.src.datasets.text_causal_language_modeling_ds.CustomDataset
+    )
+    train_dataframe: str = "/path/to/train.csv"
+    validation_strategy: str = "automatic"
+    validation_dataframe: str = ""
+    validation_size: float = 0.01
+
+    data_sample: float = 1.0
+    data_sample_choice: Tuple[str, ...] = ("Train", "Validation")
+
+    prompt_column: Tuple[str, ...] = ("instruction", "input")
+    answer_column: str = "output"
+    parent_column: str = "None"
+
+    text_prompt_start: str = "<|prompt|>"
+    text_answer_separator: str = "<|answer|>"
+
+    add_eos_token_to_prompt: bool = True
+    add_eos_token_to_answer: bool = True
+    mask_prompt_labels: bool = True
+
+    _allowed_file_extensions: Tuple[str, ...] = ("csv", "pq")
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self._possible_values["train_dataframe"] = possible_values.Files(
+            prefer_with=lambda path: "train" in path
+        )
+        self._possible_values["validation_strategy"] = possible_values.String(
+            values=(
+                ("custom", "Custom holdout validation"),
+                ("automatic", "Automatic holdout validation"),
+            ),
+            allow_custom=False,
+        )
+        self._possible_values["validation_dataframe"] = possible_values.Files(
+            add_none=True, prefer_with=lambda path: "val" in path
+        )
+        self._possible_values["validation_size"] = (0.01, 0.95, 0.01)
+        self._possible_values["data_sample"] = (0.05, 1, 0.05)
+        self._possible_values["data_sample_choice"] = ["Train", "Validation"]
+        self._possible_values["prompt_column"] = possible_values.Columns(
+            prefer_with=lambda column: column in ("instruction", "prompt")
+        )
+        self._possible_values["answer_column"] = possible_values.Columns(
+            prefer_with=lambda column: column in ("answer", "output")
+        )
+        self._possible_values["parent_column"] = possible_values.Columns(
+            prefer_with=lambda column: column in ("parent"), add_none=True
+        )
+
+        self._nesting.add(
+            ["validation_dataframe"],
+            [Dependency(key="validation_strategy", value="custom", is_set=True)],
+        )
+
+        self._nesting.add(
+            ["validation_size"],
+            [Dependency(key="validation_strategy", value="automatic", is_set=True)],
+        )
+        self._nesting.add(
+            ["data_sample_choice"],
+            [Dependency(key="data_sample", value=1, is_set=False)],
+        )
+
+        self._visibility["dataset_class"] = -1
+
+
+@dataclass
 class ConfigNLPCausalLMTraining(DefaultConfig):
     loss_class: Any = classification_losses.Losses
     loss_function: str = "CrossEntropy"
@@ -114,78 +186,6 @@ class ConfigNLPCausalLMTraining(DefaultConfig):
 
 
 @dataclass
-class ConfigNLPCausalLMDataset(DefaultConfig):
-    dataset_class: Any = (
-        llm_studio.src.datasets.text_causal_language_modeling_ds.CustomDataset
-    )
-    train_dataframe: str = "/path/to/train.csv"
-    validation_strategy: str = "automatic"
-    validation_dataframe: str = ""
-    validation_size: float = 0.01
-
-    data_sample: float = 1.0
-    data_sample_choice: Tuple[str, ...] = ("Train", "Validation")
-
-    prompt_column: Tuple[str, ...] = ("instruction", "input")
-    answer_column: str = "output"
-    parent_column: str = "None"
-
-    text_prompt_start: str = "<|prompt|>"
-    text_answer_separator: str = "<|answer|>"
-
-    add_eos_token_to_prompt: bool = True
-    add_eos_token_to_answer: bool = True
-    mask_prompt_labels: bool = True
-
-    _allowed_file_extensions: Tuple[str, ...] = ("csv", "pq")
-
-    def __post_init__(self):
-        super().__post_init__()
-
-        self._possible_values["train_dataframe"] = possible_values.Files(
-            prefer_with=lambda path: "train" in path
-        )
-        self._possible_values["validation_strategy"] = possible_values.String(
-            values=(
-                ("custom", "Custom holdout validation"),
-                ("automatic", "Automatic holdout validation"),
-            ),
-            allow_custom=False,
-        )
-        self._possible_values["validation_dataframe"] = possible_values.Files(
-            add_none=True, prefer_with=lambda path: "val" in path
-        )
-        self._possible_values["validation_size"] = (0.01, 0.95, 0.01)
-        self._possible_values["data_sample"] = (0.05, 1, 0.05)
-        self._possible_values["data_sample_choice"] = ["Train", "Validation"]
-        self._possible_values["prompt_column"] = possible_values.Columns(
-            prefer_with=lambda column: column in ("instruction", "prompt")
-        )
-        self._possible_values["answer_column"] = possible_values.Columns(
-            prefer_with=lambda column: column in ("answer", "output")
-        )
-        self._possible_values["parent_column"] = possible_values.Columns(
-            prefer_with=lambda column: column in ("parent"), add_none=True
-        )
-
-        self._nesting.add(
-            ["validation_dataframe"],
-            [Dependency(key="validation_strategy", value="custom", is_set=True)],
-        )
-
-        self._nesting.add(
-            ["validation_size"],
-            [Dependency(key="validation_strategy", value="automatic", is_set=True)],
-        )
-        self._nesting.add(
-            ["data_sample_choice"],
-            [Dependency(key="data_sample", value=1, is_set=False)],
-        )
-
-        self._visibility["dataset_class"] = -1
-
-
-@dataclass
 class ConfigNLPCausalLMTokenizer(DefaultConfig):
     max_length_prompt: int = 256
     max_length_answer: int = 256
@@ -236,12 +236,14 @@ class ConfigNLPCausalLMArchitecture(DefaultConfig):
 class ConfigNLPAugmentation(DefaultConfig):
     nlp_augmentations_class: Any = BaseNLPAug
     token_mask_probability: float = 0
-    random_parent_sample_probability: float = 0
+    skip_parent_probability: float = 0
+    random_parent_probability: float = 0
 
     def __post_init__(self):
         super().__post_init__()
         self._possible_values["token_mask_probability"] = (0, 0.9, 0.05)
-        self._possible_values["random_parent_sample_probability"] = (0, 1.0, 0.05)
+        self._possible_values["skip_parent_probability"] = (0, 1.0, 0.05)
+        self._possible_values["random_parent_probability"] = (0, 1.0, 0.05)
         self._visibility["nlp_augmentations_class"] = -1
 
 
@@ -354,13 +356,13 @@ class ConfigProblemBase(DefaultConfig):
     tokenizer: ConfigNLPCausalLMTokenizer = field(
         default_factory=ConfigNLPCausalLMTokenizer
     )
-    augmentation: ConfigNLPAugmentation = field(default_factory=ConfigNLPAugmentation)
     architecture: ConfigNLPCausalLMArchitecture = field(
         default_factory=ConfigNLPCausalLMArchitecture
     )
     training: ConfigNLPCausalLMTraining = field(
         default_factory=ConfigNLPCausalLMTraining
     )
+    augmentation: ConfigNLPAugmentation = field(default_factory=ConfigNLPAugmentation)
     prediction: ConfigNLPCausalLMPrediction = field(
         default_factory=ConfigNLPCausalLMPrediction
     )

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -288,15 +288,17 @@ class CustomDataset(Dataset):
         prompt = self.prompts[idx]
         answer = self.answers[idx]
 
-        if self.mode == "train" and self.cfg.dataset.parent_column != "None":
-            parent_idx = self.id_to_idx.get(self.parent_ids[idx], None)
-            if parent_idx is not None:
+        if self.cfg.dataset.parent_column != "None":
+            parent_idx = idx
+            while (parent_idx := self.id_to_idx.get(self.parent_ids[parent_idx], None)) is not None:
+                if self.mode == "train" and np.random.random() < self.cfg.augmentation.skip_parent_probability:
+                    break
                 prompt = self._concat_samples(prompt, int(parent_idx))
 
         if (
             self.mode == "train"
             and np.random.random()
-            < self.cfg.augmentation.random_parent_sample_probability
+            < self.cfg.augmentation.random_parent_probability
         ):
             rnd_idx = np.random.randint(len(self))
             prompt = self._concat_samples(prompt, rnd_idx)

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -65,13 +65,13 @@ class CustomDataset(Dataset):
             self.df[self.cfg.dataset.answer_column].astype(str).values.tolist()
         )
 
+        self.parent_ids = None
         if self.cfg.dataset.parent_column != "None":
             if "id" not in self.df.columns:
                 logger.warning(
-                    "When using parent column, the dataframe requires an 'id' column. "
-                    "Disabling functionality."
-                )
-                self.cfg.dataset.parent_column = "None"
+                    f"When using parent column, the dataframe requires an 'id' column. "
+                    f"Disabling functionality for mode {self.mode}."
+                )  
             else:
                 self.parent_ids = self.df[self.cfg.dataset.parent_column].values
                 self.id_to_idx = {v: k for k, v in enumerate(self.df["id"].values)}
@@ -288,7 +288,7 @@ class CustomDataset(Dataset):
         prompt = self.prompts[idx]
         answer = self.answers[idx]
 
-        if self.cfg.dataset.parent_column != "None":
+        if self.parent_ids is not None:
             parent_idx = idx
             while (
                 parent_idx := self.id_to_idx.get(self.parent_ids[parent_idx], None)

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -74,7 +74,7 @@ class CustomDataset(Dataset):
                 )
             else:
                 self.parent_ids = self.df[self.cfg.dataset.parent_column].values
-                self.id_to_idx = {v: k for k, v in enumerate(self.df["id"].values)}
+                self.df_id_to_idx = {v: k for k, v in enumerate(self.df["id"].values)}
 
         self.prompts = [self.parse_prompt(cfg, prompt) for prompt in self.prompts]
 
@@ -291,7 +291,7 @@ class CustomDataset(Dataset):
         if self.parent_ids is not None:
             parent_idx = idx
             while (
-                parent_idx := self.id_to_idx.get(self.parent_ids[parent_idx], None)
+                parent_idx := self.df_id_to_idx.get(self.parent_ids[parent_idx], None)
             ) is not None:
                 if (
                     self.mode == "train"

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -66,14 +66,14 @@ class CustomDataset(Dataset):
         )
 
         self.parent_ids = None
-        if self.cfg.dataset.parent_column != "None":
+        if self.cfg.dataset.parent_id_column != "None":
             if "id" not in self.df.columns:
                 logger.warning(
                     f"When using parent column, the dataframe requires an 'id' column. "
                     f"Disabling functionality for mode {self.mode}."
                 )
             else:
-                self.parent_ids = self.df[self.cfg.dataset.parent_column].values
+                self.parent_ids = self.df[self.cfg.dataset.parent_id_column].values
                 self.df_id_to_idx = {v: k for k, v in enumerate(self.df["id"].values)}
 
         self.prompts = [self.parse_prompt(cfg, prompt) for prompt in self.prompts]
@@ -276,10 +276,10 @@ class CustomDataset(Dataset):
         return sample
 
     def _concat_samples(self, prompt, idx):
-        rnd_parent = self.prompts[idx] + self.answers[idx]
+        parent = self.prompts[idx] + self.answers[idx]
         if self.cfg.dataset.add_eos_token_to_answer:
-            rnd_parent += self.cfg._tokenizer_eos_token
-        prompt = rnd_parent + prompt
+            parent += self.cfg._tokenizer_eos_token
+        prompt = parent + prompt
         return prompt
 
     def _read_data(self, idx: int, sample: Dict) -> Dict:

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -290,15 +290,20 @@ class CustomDataset(Dataset):
 
         if self.cfg.dataset.parent_column != "None":
             parent_idx = idx
-            while (parent_idx := self.id_to_idx.get(self.parent_ids[parent_idx], None)) is not None:
-                if self.mode == "train" and np.random.random() < self.cfg.augmentation.skip_parent_probability:
+            while (
+                parent_idx := self.id_to_idx.get(self.parent_ids[parent_idx], None)
+            ) is not None:
+                if (
+                    self.mode == "train"
+                    and np.random.random()
+                    < self.cfg.augmentation.skip_parent_probability
+                ):
                     break
                 prompt = self._concat_samples(prompt, int(parent_idx))
 
         if (
             self.mode == "train"
-            and np.random.random()
-            < self.cfg.augmentation.random_parent_probability
+            and np.random.random() < self.cfg.augmentation.random_parent_probability
         ):
             rnd_idx = np.random.randint(len(self))
             prompt = self._concat_samples(prompt, rnd_idx)

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -71,7 +71,7 @@ class CustomDataset(Dataset):
                 logger.warning(
                     f"When using parent column, the dataframe requires an 'id' column. "
                     f"Disabling functionality for mode {self.mode}."
-                )  
+                )
             else:
                 self.parent_ids = self.df[self.cfg.dataset.parent_column].values
                 self.id_to_idx = {v: k for k, v in enumerate(self.df["id"].values)}

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -289,8 +289,6 @@ class CustomDataset(Dataset):
             parent_idx = self.id_to_idx.get(self.parent_ids[idx], None)
             if parent_idx is not None:
                 prompt = self._concat_samples(prompt, int(parent_idx))
-                print(prompt)
-                print("================")
 
         if (
             self.mode == "train"

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -73,7 +73,10 @@ def get_tokenizer(cfg: Any):
         cfg.dataset.text_prompt_start, "unicode_escape"
     ).strip()
     if text_prompt_start != "":
-        if text_prompt_start not in tokenizer.get_vocab():
+        if (
+            cfg.tokenizer.add_prompt_answer_tokens
+            and text_prompt_start not in tokenizer.get_vocab()
+        ):
             tokenizer.add_tokens([text_prompt_start])
 
         cfg.tokenizer._stop_words.append(text_prompt_start)
@@ -89,7 +92,10 @@ def get_tokenizer(cfg: Any):
         cfg.dataset.text_answer_separator, "unicode_escape"
     ).strip()
     if text_answer_separator != "":
-        if text_answer_separator not in tokenizer.get_vocab():
+        if (
+            cfg.tokenizer.add_prompt_answer_tokens
+            and text_answer_separator not in tokenizer.get_vocab()
+        ):
             tokenizer.add_tokens([text_answer_separator])
 
         cfg.tokenizer._stop_words.append(text_answer_separator)

--- a/train.py
+++ b/train.py
@@ -251,17 +251,18 @@ def run_train(
                 cfg.training.batch_size * cfg.environment._world_size
             )
 
-            try:
-                data = next(tr_it)
-            except Exception:
-                failed_batches += 1
-                logger.warning("Data reading error. Skipping batch for training.")
-                if failed_batches >= epoch_steps * 0.05:
-                    raise LLMDataException(
-                        "Multiple observations in the dataset are broken, "
-                        "aborting training. Please, check the dataset."
-                    )
-                continue
+            data = next(tr_it)
+            # try:
+            #     data = next(tr_it)
+            # except Exception:
+            #     failed_batches += 1
+            #     logger.warning("Data reading error. Skipping batch for training.")
+            #     if failed_batches >= epoch_steps * 0.05:
+            #         raise LLMDataException(
+            #             "Multiple observations in the dataset are broken, "
+            #             "aborting training. Please, check the dataset."
+            #         )
+            #     continue
 
             # Batch to device
             batch = cfg.dataset.dataset_class.batch_to_device(

--- a/train.py
+++ b/train.py
@@ -1,3 +1,4 @@
+from copy import copy
 import os
 
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -577,7 +578,9 @@ def run(cfg: Any) -> None:
             step=cfg.environment._curr_step,
         )
         # re-save config
-        save_config(f"{cfg.output_directory}/cfg.p", cfg)
+        cfg_to_save = copy(cfg)
+        cfg_to_save.logging._logger.reset_external()
+        save_config(f"{cfg.output_directory}/cfg.p", cfg_to_save)
 
     val_data, val_loss, val_metric, last_batch = run_train(
         cfg=cfg,

--- a/train.py
+++ b/train.py
@@ -251,18 +251,17 @@ def run_train(
                 cfg.training.batch_size * cfg.environment._world_size
             )
 
-            data = next(tr_it)
-            # try:
-            #     data = next(tr_it)
-            # except Exception:
-            #     failed_batches += 1
-            #     logger.warning("Data reading error. Skipping batch for training.")
-            #     if failed_batches >= epoch_steps * 0.05:
-            #         raise LLMDataException(
-            #             "Multiple observations in the dataset are broken, "
-            #             "aborting training. Please, check the dataset."
-            #         )
-            #     continue
+            try:
+                data = next(tr_it)
+            except Exception:
+                failed_batches += 1
+                logger.warning("Data reading error. Skipping batch for training.")
+                if failed_batches >= epoch_steps * 0.05:
+                    raise LLMDataException(
+                        "Multiple observations in the dataset are broken, "
+                        "aborting training. Please, check the dataset."
+                    )
+                continue
 
             # Batch to device
             batch = cfg.dataset.dataset_class.batch_to_device(

--- a/train.py
+++ b/train.py
@@ -1,5 +1,5 @@
-from copy import copy
 import os
+from copy import copy
 
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
@@ -550,10 +550,6 @@ def run(cfg: Any) -> None:
                 for param in module.parameters():
                     param.requires_grad = True
                     param.data = param.data.float()
-
-    for name, param in model.named_parameters():
-        trainable_status = "trainable" if param.requires_grad else "not trainable"
-        print(f"{name}: {trainable_status}")
 
     if cfg.environment._distributed:
         model = wrap_model_distributed(model, cfg, cfg.environment.use_fsdp)


### PR DESCRIPTION
This PR addresses a few issues.

First, and foremost, it closes https://github.com/h2oai/h2o-llmstudio/issues/17
It is now possible to add a `parent_column` which maps to a separate `id` column in the data and then chains the samples.

There are also two additional augmentation settings:
`skip_parent_probability` randomly skips chained samples in training
`random_parent_probability` randomly prepends any random sample to a record

For inference, full hierarchy is prepended, or nothing if not available

New data preparation was added to support this functionality.

Additionally, this PR fixes the following issues identified while implementing this PR:
- Neptune logging did not work while re-saving the cfg
- `force_embedding_gradients` was buggy and should be fixed now

It adds also another new `add_prompt_answer_tokens` setting to manually specify whether to add separator tokens to the tokenizer.
