### PR TITLE
Batch implementation for stop tokens

### DIFF
--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -175,12 +175,13 @@ class CustomDataset(Dataset):
     ):
         output["predicted_text"] = output["predicted_text"].tolist()
         for j in range(len(output["predicted_text"])):
-            curr_text = output["predicted_text"][j].strip()
+            # Add " " at beginning and end to not miss stop tokens at beginning and end
+            curr_text = " " + output["predicted_text"][j].strip() + " "
             for stop_token in cfg.tokenizer._stop_words:
                 # Do not trim if stop token happens to be part of a regular word
                 stop_token_expanded = f" {stop_token} "
                 if curr_text.find(stop_token_expanded) != -1:
-                    curr_text = curr_text[: curr_text.find(stop_token_expanded)]
+                    curr_text = curr_text[: curr_text.find(stop_token_expanded)] + " "
             output["predicted_text"][j] = curr_text.strip()
 
         return output

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -174,11 +174,6 @@ class CustomDataset(Dataset):
         cfg: Any,
     ):
         output["predicted_text"] = output["predicted_text"].tolist()
-        # output["predicted_text"] = [
-        #     predicted_text[len(prompt) :].strip()
-        #     for predicted_text, prompt in zip(output["predicted_text"], prompts)
-        # ]
-
         for j in range(len(output["predicted_text"])):
             curr_text = output["predicted_text"][j].strip()
             for stop_token in cfg.tokenizer._stop_words:

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -182,8 +182,10 @@ class CustomDataset(Dataset):
         for j in range(len(output["predicted_text"])):
             curr_text = output["predicted_text"][j].strip()
             for stop_token in cfg.tokenizer._stop_words:
-                if curr_text.endswith(stop_token):
-                    curr_text = curr_text[: -len(stop_token)]
+                # Do not trim if stop token happens to be part of a regular word
+                stop_token_expanded = f" {stop_token} "
+                if curr_text.find(stop_token_expanded) != -1:
+                    curr_text = curr_text[: curr_text.find(stop_token_expanded)]
             output["predicted_text"][j] = curr_text.strip()
 
         return output

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -69,38 +69,11 @@ def get_tokenizer(cfg: Any):
         filter(None, cfg.prediction.stop_tokens.split(","))
     )
 
-    text_prompt_start = codecs.decode(
-        cfg.dataset.text_prompt_start, "unicode_escape"
-    ).strip()
-    if text_prompt_start != "":
-        if text_prompt_start not in tokenizer.get_vocab():
-            tokenizer.add_tokens([text_prompt_start])
-
-        cfg.tokenizer._stop_words.append(text_prompt_start)
-
-        if (
-            hasattr(cfg.prediction, "batch_size_inference")
-            and cfg.prediction.batch_size_inference != 1
-        ):
-            cfg.prediction.batch_size_inference = 1
-            if cfg.environment._local_rank == 0:
-                logger.info("Forcing inference batch size to 1 due to stop tokens.")
-    text_answer_separator = codecs.decode(
-        cfg.dataset.text_answer_separator, "unicode_escape"
-    ).strip()
-    if text_answer_separator != "":
-        if text_answer_separator not in tokenizer.get_vocab():
-            tokenizer.add_tokens([text_answer_separator])
-
-        cfg.tokenizer._stop_words.append(text_answer_separator)
-
-        if (
-            hasattr(cfg.prediction, "batch_size_inference")
-            and cfg.prediction.batch_size_inference != 1
-        ):
-            cfg.prediction.batch_size_inference = 1
-            if cfg.environment._local_rank == 0:
-                logger.info("Forcing inference batch size to 1 due to stop tokens.")
+    for stop_word in [cfg.dataset.text_prompt_start, cfg.dataset.text_answer_separator]:
+        stop_word = codecs.decode(stop_word, "unicode_escape").strip()
+        if stop_word != "":
+            tokenizer.add_tokens([stop_word])
+            cfg.tokenizer._stop_words.append(stop_word)
 
     cfg.tokenizer._vocab_length = len(tokenizer.vocab)
 

--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -102,12 +102,14 @@ class Model(nn.Module):
         generation_function: GenerationMixin.generate = self.backbone.generate
 
         verbosity = transformers_logging.get_verbosity()
-        stopping_criteria = StoppingCriteriaList[
-            TokenStoppingCriteria(
-                stop_word_ids=self.cfg.tokenizer._stop_words_ids,
-                prompt_input_ids_len=batch["prompt_input_ids"].shape[1],
-            )
-        ]
+        stopping_criteria = StoppingCriteriaList(
+            [
+                TokenStoppingCriteria(
+                    stop_word_ids=self.cfg.tokenizer._stop_words_ids,
+                    prompt_input_ids_len=batch["prompt_input_ids"].shape[1],
+                )
+            ]
+        )
 
         transformers_logging.set_verbosity_error()
         output = generation_function(

--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -102,10 +102,12 @@ class Model(nn.Module):
         generation_function: GenerationMixin.generate = self.backbone.generate
 
         verbosity = transformers_logging.get_verbosity()
-        stopping_criteria = TokenStoppingCriteria(
-            stop_word_ids=self.cfg.tokenizer._stop_words_ids,
-            prompt_input_ids_len=batch["prompt_input_ids"].shape[1],
-        )
+        stopping_criteria = StoppingCriteriaList[
+            TokenStoppingCriteria(
+                stop_word_ids=self.cfg.tokenizer._stop_words_ids,
+                prompt_input_ids_len=batch["prompt_input_ids"].shape[1],
+            )
+        ]
 
         transformers_logging.set_verbosity_error()
         output = generation_function(

--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -28,14 +28,19 @@ class TokenStoppingCriteria(StoppingCriteria):
         self.stop_word_ids = stop_word_ids
 
     def should_stop(
-            self, generated_ids: torch.LongTensor, stop_word_id: torch.Tensor,
+        self,
+        generated_ids: torch.LongTensor,
+        stop_word_id: torch.Tensor,
     ):
         if len(stop_word_id.shape) == 0:
             return (
-                    torch.mean(((generated_ids == stop_word_id).sum(1) > 0).float()) == 1
+                torch.mean(((generated_ids == stop_word_id).sum(1) > 0).float()) == 1
             ).item()
         else:
-            return self.get_num_vector_found_in_matrix_rows(stop_word_id, generated_ids) == generated_ids.shape[0]
+            return (
+                self.get_num_vector_found_in_matrix_rows(stop_word_id, generated_ids)
+                == generated_ids.shape[0]
+            )
 
     @staticmethod
     def get_num_vector_found_in_matrix_rows(vector, matrix):
@@ -51,16 +56,16 @@ class TokenStoppingCriteria(StoppingCriteria):
             # stride through the vector
             for i in range(len(row) - len(vector) + 1):
                 # check if the vector contains the tensor
-                if torch.all(row[i:i + len(vector)] == vector):
+                if torch.all(row[i : i + len(vector)] == vector):
                     found += 1
                     break
 
         return found
 
     def __call__(
-            self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs
     ):
-        generated_ids = input_ids[:, self.prompt_input_ids_len:]
+        generated_ids = input_ids[:, self.prompt_input_ids_len :]
         for stop_word_id in self.stop_word_ids:
             if self.should_stop(generated_ids, stop_word_id.to(generated_ids.device)):
                 return True
@@ -107,7 +112,7 @@ class Model(nn.Module):
 
     def generate(self, batch: Dict, cfg: Any):
         pad_token_id = (
-                self.backbone.config.pad_token_id or self.backbone.config.eos_token_id
+            self.backbone.config.pad_token_id or self.backbone.config.eos_token_id
         )
 
         batch = batch_padding(
@@ -158,9 +163,9 @@ class Model(nn.Module):
         return output
 
     def forward(
-            self,
-            batch: Dict,
-            calculate_loss: bool = True,
+        self,
+        batch: Dict,
+        calculate_loss: bool = True,
     ) -> Dict:
         outputs: Dict = {}
 

--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -28,14 +28,37 @@ class TokenStoppingCriteria(StoppingCriteria):
         self.stop_word_ids = stop_word_ids
 
     def should_stop(
-        self, generated_ids: torch.LongTensor, stop_word_id: torch.FloatTensor
+            self, generated_ids: torch.LongTensor, stop_word_id: torch.Tensor,
     ):
-        return (
-            torch.mean(((generated_ids == stop_word_id).sum(1) > 0).float()) == 1
-        ).item()
+        if len(stop_word_id.shape) == 0:
+            return (
+                    torch.mean(((generated_ids == stop_word_id).sum(1) > 0).float()) == 1
+            ).item()
+        else:
+            return self.get_num_vector_found_in_matrix_rows(stop_word_id, generated_ids) == generated_ids.shape[0]
+
+    @staticmethod
+    def get_num_vector_found_in_matrix_rows(vector, matrix):
+        """
+        Count the number of times a vector is found in a matrix row.
+        If the vector is found in a row, the search stops and the next row is searched.
+        """
+        assert len(vector.shape) == 1
+        assert len(matrix.shape) == 2
+
+        found = 0
+        for row in matrix:
+            # stride through the vector
+            for i in range(len(row) - len(vector) + 1):
+                # check if the vector contains the tensor
+                if torch.all(row[i:i + len(vector)] == vector):
+                    found += 1
+                    break
+
+        return found
 
     def __call__(
-        self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs
+            self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs
     ):
         generated_ids = input_ids[:, self.prompt_input_ids_len:]
         for stop_word_id in self.stop_word_ids:
@@ -84,7 +107,7 @@ class Model(nn.Module):
 
     def generate(self, batch: Dict, cfg: Any):
         pad_token_id = (
-            self.backbone.config.pad_token_id or self.backbone.config.eos_token_id
+                self.backbone.config.pad_token_id or self.backbone.config.eos_token_id
         )
 
         batch = batch_padding(
@@ -135,9 +158,9 @@ class Model(nn.Module):
         return output
 
     def forward(
-        self,
-        batch: Dict,
-        calculate_loss: bool = True,
+            self,
+            batch: Dict,
+            calculate_loss: bool = True,
     ) -> Dict:
         outputs: Dict = {}
 

--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -37,7 +37,7 @@ class TokenStoppingCriteria(StoppingCriteria):
     def __call__(
         self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs
     ):
-        generated_ids = input_ids[:, len(self.prompt_input_ids_len)]
+        generated_ids = input_ids[:, self.prompt_input_ids_len:]
         for stop_word_id in self.stop_word_ids:
             if self.should_stop(generated_ids, stop_word_id.to(generated_ids.device)):
                 return True

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -1,0 +1,29 @@
+from unittest import mock
+
+import numpy as np
+
+from llm_studio.src.datasets.text_causal_language_modeling_ds import CustomDataset
+
+
+def test_clean_output():
+    output = {"predicted_text": np.array(["This is a test",
+                                          "This is a test <stop> This is a test",
+                                          "This is a test <stop2> This is a test",
+                                          "This is a test <stop3> <stop> This is a test",
+                                          "<stop2> <stop> This is a test",
+                                          "This is a test <stop>",
+                                          ])}
+
+    cfg = mock.MagicMock()
+    cfg.tokenizer._stop_words = ["<stop>", "<stop2>", "<stop3>", "tes"]
+
+    predicted_text_clean = CustomDataset.clean_output(output=output,
+                                                      prompts=None,
+                                                      cfg=cfg)["predicted_text"]
+    assert predicted_text_clean == ["This is a test",
+                                    "This is a test",
+                                    "This is a test",
+                                    "This is a test",
+                                    "",
+                                    "This is a test"
+                                    ]

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -6,24 +6,30 @@ from llm_studio.src.datasets.text_causal_language_modeling_ds import CustomDatas
 
 
 def test_clean_output():
-    output = {"predicted_text": np.array(["This is a test",
-                                          "This is a test <stop> This is a test",
-                                          "This is a test <stop2> This is a test",
-                                          "This is a test <stop3> <stop> This is a test",
-                                          "<stop2> <stop> This is a test",
-                                          "This is a test <stop>",
-                                          ])}
+    output = {
+        "predicted_text": np.array(
+            [
+                "This is a test",
+                "This is a test <stop> This is a test",
+                "This is a test <stop2> This is a test",
+                "This is a test <stop3> <stop> This is a test",
+                "<stop2> <stop> This is a test",
+                "This is a test <stop>",
+            ]
+        )
+    }
 
     cfg = mock.MagicMock()
     cfg.tokenizer._stop_words = ["<stop>", "<stop2>", "<stop3>", "tes"]
 
-    predicted_text_clean = CustomDataset.clean_output(output=output,
-                                                      prompts=None,
-                                                      cfg=cfg)["predicted_text"]
-    assert predicted_text_clean == ["This is a test",
-                                    "This is a test",
-                                    "This is a test",
-                                    "This is a test",
-                                    "",
-                                    "This is a test"
-                                    ]
+    predicted_text_clean = CustomDataset.clean_output(
+        output=output, prompts=None, cfg=cfg
+    )["predicted_text"]
+    assert predicted_text_clean == [
+        "This is a test",
+        "This is a test",
+        "This is a test",
+        "This is a test",
+        "",
+        "This is a test",
+    ]

--- a/tests/models/test_text_causal_language_modeling_model.py
+++ b/tests/models/test_text_causal_language_modeling_model.py
@@ -1,0 +1,25 @@
+import torch
+
+from llm_studio.src.models.text_causal_language_modeling_model import TokenStoppingCriteria
+
+
+def test_token_stopping_criteria():
+    token_stopping_criteria = TokenStoppingCriteria(stop_word_ids=torch.tensor([0, 1, 2, 8]), prompt_input_ids_len=4)
+
+    input_ids = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+                              [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                              [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+                              [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                              [4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+                              [5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+                              ]).long()
+
+    # prompt input len is 4, so generated ids of last sample of the batch are
+    # [9, 10, 11, 12, 13, 14], do not trigger stopping criteria
+    assert not token_stopping_criteria(input_ids=input_ids, scores=None)
+
+    token_stopping_criteria = TokenStoppingCriteria(stop_word_ids=torch.tensor([6]), prompt_input_ids_len=0)
+
+    # first item reads [ 0,  1,  2,  3,  4,  5], so do not trigger stopping criteria
+    assert not token_stopping_criteria(input_ids=input_ids[:, :6], scores=None)
+    assert token_stopping_criteria(input_ids=input_ids[:, :7], scores=None)

--- a/tests/models/test_text_causal_language_modeling_model.py
+++ b/tests/models/test_text_causal_language_modeling_model.py
@@ -38,7 +38,6 @@ def test_token_stopping_criteria():
         stop_word_ids=torch.tensor([[6, 7]]), prompt_input_ids_len=0
     )
 
-    # first item reads [ 0,  1,  2,  3,  4,  5], so do not trigger stopping criteria
     assert not token_stopping_criteria(input_ids=input_ids[:, :6], scores=None)
     assert not token_stopping_criteria(input_ids=input_ids[:, :7], scores=None)
     assert token_stopping_criteria(input_ids=input_ids[:, :8], scores=None)

--- a/tests/models/test_text_causal_language_modeling_model.py
+++ b/tests/models/test_text_causal_language_modeling_model.py
@@ -23,3 +23,11 @@ def test_token_stopping_criteria():
     # first item reads [ 0,  1,  2,  3,  4,  5], so do not trigger stopping criteria
     assert not token_stopping_criteria(input_ids=input_ids[:, :6], scores=None)
     assert token_stopping_criteria(input_ids=input_ids[:, :7], scores=None)
+
+    # Test stopping criteria with compound tokens
+    token_stopping_criteria = TokenStoppingCriteria(stop_word_ids=torch.tensor([[6, 7]]), prompt_input_ids_len=0)
+
+    # first item reads [ 0,  1,  2,  3,  4,  5], so do not trigger stopping criteria
+    assert not token_stopping_criteria(input_ids=input_ids[:, :6], scores=None)
+    assert not token_stopping_criteria(input_ids=input_ids[:, :7], scores=None)
+    assert token_stopping_criteria(input_ids=input_ids[:, :8], scores=None)

--- a/tests/models/test_text_causal_language_modeling_model.py
+++ b/tests/models/test_text_causal_language_modeling_model.py
@@ -1,31 +1,42 @@
 import torch
 
-from llm_studio.src.models.text_causal_language_modeling_model import TokenStoppingCriteria
+from llm_studio.src.models.text_causal_language_modeling_model import (
+    TokenStoppingCriteria,
+)
 
 
 def test_token_stopping_criteria():
-    token_stopping_criteria = TokenStoppingCriteria(stop_word_ids=torch.tensor([0, 1, 2, 8]), prompt_input_ids_len=4)
+    token_stopping_criteria = TokenStoppingCriteria(
+        stop_word_ids=torch.tensor([0, 1, 2, 8]), prompt_input_ids_len=4
+    )
 
-    input_ids = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-                              [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                              [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-                              [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-                              [4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
-                              [5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
-                              ]).long()
+    input_ids = torch.tensor(
+        [
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            [2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            [4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+            [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+        ]
+    ).long()
 
     # prompt input len is 4, so generated ids of last sample of the batch are
     # [9, 10, 11, 12, 13, 14], do not trigger stopping criteria
     assert not token_stopping_criteria(input_ids=input_ids, scores=None)
 
-    token_stopping_criteria = TokenStoppingCriteria(stop_word_ids=torch.tensor([6]), prompt_input_ids_len=0)
+    token_stopping_criteria = TokenStoppingCriteria(
+        stop_word_ids=torch.tensor([6]), prompt_input_ids_len=0
+    )
 
     # first item reads [ 0,  1,  2,  3,  4,  5], so do not trigger stopping criteria
     assert not token_stopping_criteria(input_ids=input_ids[:, :6], scores=None)
     assert token_stopping_criteria(input_ids=input_ids[:, :7], scores=None)
 
     # Test stopping criteria with compound tokens
-    token_stopping_criteria = TokenStoppingCriteria(stop_word_ids=torch.tensor([[6, 7]]), prompt_input_ids_len=0)
+    token_stopping_criteria = TokenStoppingCriteria(
+        stop_word_ids=torch.tensor([[6, 7]]), prompt_input_ids_len=0
+    )
 
     # first item reads [ 0,  1,  2,  3,  4,  5], so do not trigger stopping criteria
     assert not token_stopping_criteria(input_ids=input_ids[:, :6], scores=None)


### PR DESCRIPTION
This PR adds a batch implementation for stop token usage in `.generate`
- `.generate` will stop if one stop token occurs at least once in every sample of the batch
- `clean_output` will remove any text that comes after a stop token (together with the stop token itself).