### PR TITLE
introducing busy_dialog for waiting operations

### DIFF
--- a/app_utils/initializers.py
+++ b/app_utils/initializers.py
@@ -7,10 +7,8 @@ from bokeh.resources import Resources as BokehResources
 from h2o_wave import Q
 
 from app_utils.sections.common import interface
-from llm_studio.src.utils.config_utils import (
-    load_config_py,
-    save_config_yaml,
-)
+from llm_studio.src.utils.config_utils import load_config_py, save_config_yaml
+
 from .config import default_cfg
 from .db import Database, Dataset
 from .migration import migrate_app

--- a/app_utils/sections/dataset.py
+++ b/app_utils/sections/dataset.py
@@ -32,12 +32,17 @@ from app_utils.utils import (
     s3_download,
     s3_file_options,
 )
+<<<<<<< HEAD
 from app_utils.wave_utils import ui_table_from_df
 from llm_studio.src.utils.config_utils import (
     load_config_py,
     load_config_yaml,
     save_config_yaml,
 )
+=======
+from app_utils.wave_utils import busy_dialog, ui_table_from_df
+from llm_studio.src.utils.config_utils import load_config
+>>>>>>> e68f144 (no dialog for chat)
 from llm_studio.src.utils.data_utils import (
     get_fill_columns,
     read_dataframe,
@@ -507,12 +512,11 @@ async def dataset_import(
             items = [ui.markup(content=header), ui.message_bar(text=text), plot_item]
             valid_visualization = True
 
-            q.page["meta"].dialog = ui.dialog(
+            await busy_dialog(
+                q=q,
                 title="Performing sanity checks on the data",
-                blocking=True,
-                items=[ui.progress(label="Please be patient...")],
+                text="Please be patient...",
             )
-            await q.page.save()
             # add one-second delay for datasets where sanity check is instant
             # to avoid flickering dialog
             time.sleep(1)

--- a/app_utils/sections/dataset.py
+++ b/app_utils/sections/dataset.py
@@ -32,17 +32,14 @@ from app_utils.utils import (
     s3_download,
     s3_file_options,
 )
-<<<<<<< HEAD
-from app_utils.wave_utils import ui_table_from_df
+
+from app_utils.wave_utils import busy_dialog, ui_table_from_df
 from llm_studio.src.utils.config_utils import (
     load_config_py,
     load_config_yaml,
     save_config_yaml,
 )
-=======
-from app_utils.wave_utils import busy_dialog, ui_table_from_df
-from llm_studio.src.utils.config_utils import load_config
->>>>>>> e68f144 (no dialog for chat)
+
 from llm_studio.src.utils.data_utils import (
     get_fill_columns,
     read_dataframe,

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -32,7 +32,7 @@ from app_utils.utils import (
     remove_model_type,
     start_experiment,
 )
-from app_utils.wave_utils import ui_table_from_df, wave_theme
+from app_utils.wave_utils import busy_dialog, ui_table_from_df, wave_theme
 from llm_studio.src.datasets.text_utils import get_tokenizer
 from llm_studio.src.utils.config_utils import (
     convert_cfg_to_nested_dictionary,
@@ -1144,6 +1144,7 @@ async def parse_param(q: Q, cfg, prompt):
 
 async def experiment_chat(q: Q) -> None:
 
+    await busy_dialog(q=q, title="Chat", text="Getting the answer...")
     prompt = q.client["experiment/display/chat/chatbot"]
 
     if prompt.lower().startswith("--"):
@@ -1596,6 +1597,13 @@ async def experiment_push_to_huggingface_dialog(q: Q, error: str = ""):
             ),
         ]
     elif q.args["experiment/display/push_to_huggingface_submit"]:
+
+        await busy_dialog(
+            q=q,
+            title="Exporting to HuggingFace ",
+            text="Model size can affect the export time significantly.",
+        )
+
         experiment_path = q.client["experiment/display/experiment_path"]
         cfg, model, tokenizer = load_cfg_model_tokenizer(experiment_path, device="cpu")
         if hasattr(cfg.training, "lora") and cfg.training.lora:

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -1144,7 +1144,6 @@ async def parse_param(q: Q, cfg, prompt):
 
 async def experiment_chat(q: Q) -> None:
 
-    await busy_dialog(q=q, title="Chat", text="Getting the answer...")
     prompt = q.client["experiment/display/chat/chatbot"]
 
     if prompt.lower().startswith("--"):

--- a/app_utils/wave_utils.py
+++ b/app_utils/wave_utils.py
@@ -359,3 +359,19 @@ async def report_error(q: Q):
     q.page[card_name].items[13].text_xs.visible = True
 
     await q.page.save()
+
+
+async def busy_dialog(q: Q, title: str = "", text: str = "") -> None:
+    """Creates busy dialog"""
+
+    q.page["meta"].dialog = ui.dialog(
+        title=title,
+        primary=True,
+        items=[
+            ui.progress(label=text),
+        ],
+        blocking=True,
+    )
+    await q.page.save()
+    await q.sleep(0.1)
+    q.page["meta"].dialog = None

--- a/app_utils/wave_utils.py
+++ b/app_utils/wave_utils.py
@@ -361,7 +361,9 @@ async def report_error(q: Q):
     await q.page.save()
 
 
-async def busy_dialog(q: Q, title: str = "", text: str = "") -> None:
+async def busy_dialog(
+    q: Q, title: str = "", text: str = "", force_wait: bool = False
+) -> None:
     """Creates busy dialog"""
 
     q.page["meta"].dialog = ui.dialog(
@@ -373,5 +375,6 @@ async def busy_dialog(q: Q, title: str = "", text: str = "") -> None:
         blocking=True,
     )
     await q.page.save()
-    await q.sleep(0.1)
+    if force_wait:
+        await q.sleep(1)
     q.page["meta"].dialog = None


### PR DESCRIPTION
This PR
- Introduces `busy_dialog` under `wave_utils.py`. Instead of defining `q.page["meta"].dialog `+ `q.page.save()` handling everywhere, one can use this as a one-liner and just pass title&text info
- Calling `busy_dialog` when submitting models to HF hub. Seeing the "loading" wheel is not as informative and it's easy to assume the app might have gotten stuck since it takes quite a bit of time to upload LLM models. 
- ~~Calling `busy_dialog` when waiting for the chatbot answers as well. Especially for the chatbots that are slow and the prompts requiring long answers, seeing the dialog can be more informative than seeing the "loading" wheel. (Best would be seeing a loading chat bubble though. Wave doesn't support it yet I guess?)~~
- The usage of busy_dialog can be extended in the code base to have a consistent blocker dialog behavior across the pages/operations
 
Wonder what you think

### How it looks:

https://user-images.githubusercontent.com/70659545/234353838-a773ebb4-5e6d-4a39-be5d-55363a4138e7.mov

vs

<img width="1466" alt="Screenshot 2023-04-25 at 20 03 54" src="https://user-images.githubusercontent.com/70659545/234354790-48e2ae83-a23d-4dba-9ba1-2d74eff4a38c.png">
