### PR TITLE
Fix copy config

### DIFF
--- a/app_utils/sections/dataset.py
+++ b/app_utils/sections/dataset.py
@@ -32,14 +32,12 @@ from app_utils.utils import (
     s3_download,
     s3_file_options,
 )
-
 from app_utils.wave_utils import busy_dialog, ui_table_from_df
 from llm_studio.src.utils.config_utils import (
     load_config_py,
     load_config_yaml,
     save_config_yaml,
 )
-
 from llm_studio.src.utils.data_utils import (
     get_fill_columns,
     read_dataframe,

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -19,6 +19,7 @@ from functools import partial
 from typing import Any, DefaultDict, List, Optional, Tuple, Type, Union
 
 import GPUtil
+import dill
 import numpy as np
 import pandas as pd
 import psutil
@@ -1851,9 +1852,11 @@ def copy_config(cfg: Any) -> Any:
     """
     # make unique yaml file using uuid
     os.makedirs("output", exist_ok=True)
-    tmp_file = os.path.join("output/", str(uuid.uuid4()) + ".yaml")
-    save_config_yaml(tmp_file, cfg)
-    cfg = load_config_yaml(tmp_file)
+    tmp_file = os.path.join("output/", str(uuid.uuid4()) + ".p")
+    with open(tmp_file, "wb") as f:
+        dill.dump(cfg, f)
+    with open(tmp_file, "rb") as f:
+        cfg = dill.load(f)
     os.remove(tmp_file)
     return cfg
 

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -109,6 +109,7 @@ def start_process(
 
     num_gpus = len(gpu_list)
     config_name = os.path.join(cfg.output_directory, "cfg.yaml")
+    env = {**os.environ, **secrets}
 
     if num_gpus == 0:
         p = subprocess.Popen(
@@ -120,7 +121,7 @@ def start_process(
                 "-Q",
                 ",".join([str(x) for x in process_queue]),
             ],
-            env={**os.environ, **secrets},
+            env=env,
         )
     # Do not delete for debug purposes
     # elif num_gpus == 1:
@@ -142,6 +143,7 @@ def start_process(
         p = subprocess.Popen(
             [
                 "env",
+                f"CUDA_VISIBLE_DEVICES={','.join(gpu_list)}",
                 "torchrun",
                 f"--nproc_per_node={str(num_gpus)}",
                 f"--master_port={str(free_port)}",
@@ -151,11 +153,7 @@ def start_process(
                 "-Q",
                 ",".join([str(x) for x in process_queue]),
             ],
-            env={
-                **os.environ,
-                **secrets,
-                "CUDA_VISIBLE_DEVICES" " ": ",".join(gpu_list),
-            },
+            env=env,
         )
     logger.info(f"Percentage of RAM memory used: {psutil.virtual_memory().percent}")
 

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -18,7 +18,6 @@ from contextlib import closing
 from functools import partial
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple, Type, Union
 
-import dill
 import GPUtil
 import numpy as np
 import pandas as pd
@@ -44,7 +43,6 @@ from llm_studio.src.utils.config_utils import (
 from llm_studio.src.utils.data_utils import is_valid_data_frame, read_dataframe
 from llm_studio.src.utils.export_utils import get_size_str
 from llm_studio.src.utils.type_annotations import KNOWN_TYPE_ANNOTATIONS
-
 from .config import default_cfg
 
 logger = logging.getLogger(__name__)

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -99,7 +99,8 @@ def start_process(
     Args:
         cfg: config
         gpu_list: list of GPUs to use for the training
-
+        process_queue: list of processes to wait for before starting the training
+        secrets: dictionary of secrets to pass to the training process
     Returns:
         Process
 

--- a/llm_studio/src/utils/utils.py
+++ b/llm_studio/src/utils/utils.py
@@ -33,10 +33,8 @@ def set_environment(cfg):
     """Sets and checks environment settings"""
     if not cfg.environment.openai_api_token:
         cfg.environment.openai_api_token = os.getenv("OPENAI_API_KEY", "")
-        print("OPENAI_API_KEY", cfg.environment.openai_api_token)
     if not cfg.logging.neptune_api_token:
         cfg.logging.neptune_api_token = os.getenv("NEPTUNE_API_TOKEN", "")
-        print("NEPTUNE_API_TOKEN", cfg.logging.neptune_api_token)
     os.environ["OPENAI_API_KEY"] = cfg.environment.openai_api_token
     openai.api_key = cfg.environment.openai_api_token
 

--- a/llm_studio/src/utils/utils.py
+++ b/llm_studio/src/utils/utils.py
@@ -33,8 +33,8 @@ def set_environment(cfg):
     """Sets and checks environment settings"""
     if not cfg.environment.openai_api_token:
         cfg.environment.openai_api_token = os.getenv("OPENAI_API_KEY", "")
-    if not cfg.logger.neptune_api_token:
-        cfg.logger.neptune_api_token = os.getenv("NEPTUNE_API_TOKEN", "")
+    if not cfg.logging.neptune_api_token:
+        cfg.logging.neptune_api_token = os.getenv("NEPTUNE_API_TOKEN", "")
 
     os.environ["OPENAI_API_KEY"] = cfg.environment.openai_api_token
     openai.api_key = cfg.environment.openai_api_token

--- a/llm_studio/src/utils/utils.py
+++ b/llm_studio/src/utils/utils.py
@@ -31,6 +31,10 @@ def set_seed(seed: int = 1234) -> None:
 
 def set_environment(cfg):
     """Sets and checks environment settings"""
+    if not cfg.environment.openai_api_token:
+        cfg.environment.openai_api_token = os.getenv("OPENAI_API_KEY", "")
+    if not cfg.logger.neptune_api_token:
+        cfg.logger.neptune_api_token = os.getenv("NEPTUNE_API_TOKEN", "")
 
     os.environ["OPENAI_API_KEY"] = cfg.environment.openai_api_token
     openai.api_key = cfg.environment.openai_api_token

--- a/llm_studio/src/utils/utils.py
+++ b/llm_studio/src/utils/utils.py
@@ -33,9 +33,10 @@ def set_environment(cfg):
     """Sets and checks environment settings"""
     if not cfg.environment.openai_api_token:
         cfg.environment.openai_api_token = os.getenv("OPENAI_API_KEY", "")
+        print("OPENAI_API_KEY", cfg.environment.openai_api_token)
     if not cfg.logging.neptune_api_token:
         cfg.logging.neptune_api_token = os.getenv("NEPTUNE_API_TOKEN", "")
-
+        print("NEPTUNE_API_TOKEN", cfg.logging.neptune_api_token)
     os.environ["OPENAI_API_KEY"] = cfg.environment.openai_api_token
     openai.api_key = cfg.environment.openai_api_token
 

--- a/train.py
+++ b/train.py
@@ -1,5 +1,4 @@
 import os
-from copy import copy
 
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
@@ -16,7 +15,6 @@ import time
 from distutils import util
 from typing import Any, Callable, Dict, Tuple
 
-import dill
 import numpy as np
 import pandas as pd
 import torch


### PR DESCRIPTION
Hotfix for bf1cbf6bac896f292489feadc569162d68a82363.

OpenAI secret and Neptune secret are not stored in config.yaml, so we need to set them as env variables before calling `train_wave.py ` and copy them over to the config again in `train.py`.

CLI users can:
- Specify the secrets in the config (.py/yaml), not recommended
- Use environment variables, these will be copied over to the config (but not saved in there).