### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ During the experiment, you can monitor the training progress and model performan
 ### Push to Hugging Face 🤗
 If you want to publish your model, you can export it with a single click to the [Hugging Face Hub](https://huggingface.co/)
 and share it with the community. To be able to push your model to the Hub, you need to have an API token with write access.
-You can also click the _Download model_ button to the model locally in Hugging Face format and use it in your own application.
+You can also click the **Download model** button to the model locally in Hugging Face format and use it in your own application.
 To use a converted model, you can use the following code snippet:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ During the experiment, you can monitor the training progress and model performan
 ### Push to Hugging Face 🤗
 If you want to publish your model, you can export it with a single click to the [Hugging Face Hub](https://huggingface.co/)
 and share it with the community. To be able to push your model to the Hub, you need to have an API token with write access.
-You can also click the **Download model** button to the model locally in Hugging Face format and use it in your own application.
+You can also click the **Download model** button to download the model locally.
 To use a converted model, you can use the following code snippet:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -132,6 +132,35 @@ During the experiment, you can monitor the training progress and model performan
 ### Push to Hugging Face 🤗
 If you want to publish your model, you can export it with a single click to the [Hugging Face Hub](https://huggingface.co/)
 and share it with the community. To be able to push your model to the Hub, you need to have an API token with write access.
+You can also click the _Download model_ button to the model locally in Hugging Face format and use it in your own application.
+To use a converted model, you can use the following code snippet:
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+model_name = "path_to_downloaded_model"  # either local folder or huggingface model name
+
+# Important: The prompt needs to be in the same format the model was trained with.
+# You can find an example prompt in the experiment logs.
+prompt = "<|prompt|>How are you?<|endoftext|><|answer|>"
+
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+model = AutoModelForCausalLM.from_pretrained(model_name)
+model.cuda().eval()
+
+inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=False).to("cuda")
+# generate configuration can be modified to your needs
+tokens = model.generate(
+    **inputs,
+    max_new_tokens=256,
+    temperature=0.3,
+    repetition_penalty=1.2,
+    num_beams=2
+)[0]
+tokens = tokens[inputs["input_ids"].shape[1]:]
+answer = tokenizer.decode(tokens, skip_special_tokens=True)
+print(answer)
+```
 
 ### Compare experiments
 In the **View Experiments** view, you can compare your experiments and see how different model parameters affect the model performance.

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -1,5 +1,6 @@
 import codecs
 import collections.abc
+import html
 import logging
 from typing import Any, Dict, List, Tuple, Union
 
@@ -79,7 +80,7 @@ class CustomDataset(Dataset):
         self.prompts = [self.parse_prompt(cfg, prompt) for prompt in self.prompts]
 
         if self.cfg.environment._local_rank == 0:
-            logger.info(f"Sample prompt: {self.prompts[0]}")
+            logger.info(f"Sample prompt: {html.escape(self.prompts[0])}")
 
     @staticmethod
     def parse_prompt(cfg: Any, prompt: str):


### PR DESCRIPTION
Fixes #61.

For some models, example prompts where not displayed correctly in the UI logs, e.g. if `EOS token == </s>`.
I've fixed it for the UI, terminal logs now show html formatted prompts. Not sure if there's an easy way to both get good output both in UI and in the terminal.