### PR TITLE
Creating the option to download checkpoints as models

### DIFF
--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -1095,6 +1095,25 @@ async def experiment_display(q: Q) -> None:
         )
     ]
 
+    if status != "finished":
+        buttons += [
+            ui.button(
+                name="experiment/display/download_model",
+                label="Donwload checkpoint",
+                primary=False,
+                disabled=False,
+                tooltip=None,
+            ),
+            ui.button(
+                name="experiment/display/push_to_huggingface",
+                label="Push checkpoint to huggingface",
+                primary=False,
+                disabled=False,
+                tooltip=None,
+            ),
+        ]
+
+
     if status == "finished":
         buttons += [
             ui.button(

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -1096,22 +1096,25 @@ async def experiment_display(q: Q) -> None:
     ]
 
     if status != "finished":
-        buttons += [
-            ui.button(
-                name="experiment/display/download_model",
-                label="Donwload checkpoint",
-                primary=False,
-                disabled=False,
-                tooltip=None,
-            ),
-            ui.button(
-                name="experiment/display/push_to_huggingface",
-                label="Push checkpoint to huggingface",
-                primary=False,
-                disabled=False,
-                tooltip=None,
-            ),
-        ]
+        experiment_path = q.client["experiment/display/experiment_path"]
+        cfg = load_config_yaml(os.path.join(experiment_path, "cfg.yaml"))
+        if os.path.isfile(os.path.join(cfg.output_directory, "checkpoint.pth")):
+            buttons += [
+                ui.button(
+                    name="experiment/display/download_model",
+                    label="Donwload model from checkpoint",
+                    primary=False,
+                    disabled=False,
+                    tooltip=None,
+                ),
+                ui.button(
+                    name="experiment/display/push_to_huggingface",
+                    label="Push checkpoint to huggingface",
+                    primary=False,
+                    disabled=False,
+                    tooltip=None,
+                ),
+            ]
 
 
     if status == "finished":


### PR DESCRIPTION
Something like this will enable people to run large jobs and download models mid-way, as well as not to worry about stopping a large job and not getting any model out to test.

Enables a "Download Model from checkpoint" and "Push checkpoint to huggingface" after an experiment generated a checkpoint file.

![image](https://github.com/h2oai/h2o-llmstudio/assets/11511785/2c9e404a-96ba-42f7-97d3-3b6da97d7c2b)
