### PR TITLE
Manual loss & chained setting

### DIFF
--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -40,6 +40,7 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
     text_prompt_start: str = "<|prompt|>"
     text_answer_separator: str = "<|answer|>"
 
+    limit_chained_samples: bool = False
     add_eos_token_to_prompt: bool = True
     add_eos_token_to_answer: bool = True
     mask_prompt_labels: bool = True
@@ -91,9 +92,15 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
             ["validation_size"],
             [Dependency(key="validation_strategy", value="automatic", is_set=True)],
         )
+
         self._nesting.add(
             ["data_sample_choice"],
             [Dependency(key="data_sample", value=1, is_set=False)],
+        )
+
+        self._nesting.add(
+            ["limit_chained_samples"],
+            [Dependency(key="parent_id_column", value="None", is_set=False)],
         )
 
         self._visibility["dataset_class"] = -1
@@ -102,7 +109,7 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
 @dataclass
 class ConfigNLPCausalLMTraining(DefaultConfig):
     loss_class: Any = classification_losses.Losses
-    loss_function: str = "CrossEntropy"
+    loss_function: str = "TokenCrossEntropy"
     optimizer: str = "AdamW"
 
     learning_rate: float = 0.0001
@@ -132,7 +139,7 @@ class ConfigNLPCausalLMTraining(DefaultConfig):
 
     def __post_init__(self):
         super().__post_init__()
-        self._possible_values["loss_function"] = ("CrossEntropy",)
+        self._possible_values["loss_function"] = self.loss_class.names()
         self._possible_values["optimizer"] = Optimizers.names()
 
         self._possible_values["learning_rate"] = possible_values.Number(
@@ -164,7 +171,6 @@ class ConfigNLPCausalLMTraining(DefaultConfig):
 
         self._possible_values["evaluation_epochs"] = (0.1, 1, 0.05)
 
-        self._visibility["loss_function"] = -1
         self._visibility["loss_class"] = -1
         self._visibility["drop_last_batch"] = -1
         self._visibility["differential_learning_rate_layers"] = -1

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -109,7 +109,7 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
 @dataclass
 class ConfigNLPCausalLMTraining(DefaultConfig):
     loss_class: Any = classification_losses.Losses
-    loss_function: str = "TokenCrossEntropy"
+    loss_function: str = "TokenAveragedCrossEntropy"
     optimizer: str = "AdamW"
 
     learning_rate: float = 0.0001

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -78,7 +78,7 @@ class CustomDataset(Dataset):
                 self.parent_ids = self.df[self.cfg.dataset.parent_id_column].values
                 self.df_id_to_idx = {v: k for k, v in enumerate(self.df["id"].values)}
 
-                # filter all indices where id column in df is never a parent_id of another row
+                # limit chained samples to the longest chain
                 if self.cfg.dataset.limit_chained_samples:
                     self.indices = self.indices[
                         [id not in self.parent_ids for id in self.df["id"].values]

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -78,11 +78,11 @@ class CustomDataset(Dataset):
                 self.parent_ids = self.df[self.cfg.dataset.parent_id_column].values
                 self.df_id_to_idx = {v: k for k, v in enumerate(self.df["id"].values)}
 
-                # filter all indices where parent_id is set to -1
-                self.indices = self.indices[(self.parent_ids != -1) & (self.parent_ids != "-1")]
-
                 # filter all indices where id column in df is never a parent_id of another row
-                self.indices = self.indices[[id not in self.parent_ids for id in self.df["id"].values]]
+                if self.cfg.dataset.limit_chained_samples:
+                    self.indices = self.indices[
+                        [id not in self.parent_ids for id in self.df["id"].values]
+                    ]
 
         self.prompts = [self.parse_prompt(cfg, prompt) for prompt in self.prompts]
 

--- a/llm_studio/src/losses/classification_losses.py
+++ b/llm_studio/src/losses/classification_losses.py
@@ -9,7 +9,7 @@ __all__ = ["Losses"]
 logger = logging.getLogger(__name__)
 
 
-class TokenCrossEntropyLoss(nn.Module):
+class TokenAveragedCrossEntropyLoss(nn.Module):
     def __init__(self, cfg: Any):
         super().__init__()
         self.cfg = cfg
@@ -25,7 +25,7 @@ class TokenCrossEntropyLoss(nn.Module):
         return self.loss_fn(shift_logits, shift_labels)
 
 
-class SampleCrossEntropyLoss(nn.Module):
+class SampleAveragedCrossEntropyLoss(nn.Module):
     def __init__(self, cfg: Any):
         super().__init__()
         self.cfg = cfg
@@ -46,8 +46,8 @@ class Losses:
     """Losses factory."""
 
     _losses = {
-        "TokenCrossEntropy": TokenCrossEntropyLoss,
-        "SampleCrossEntropy": SampleCrossEntropyLoss,
+        "TokenAveragedCrossEntropy": TokenAveragedCrossEntropyLoss,
+        "SampleAveragedCrossEntropy": SampleAveragedCrossEntropyLoss,
     }
 
     @classmethod

--- a/llm_studio/src/losses/classification_losses.py
+++ b/llm_studio/src/losses/classification_losses.py
@@ -1,12 +1,10 @@
 import logging
 from typing import Any, List
 
-import torch.nn.functional as F
+import torch
 
 __all__ = ["Losses"]
 
-import torch
-from torch import nn
 
 logger = logging.getLogger(__name__)
 
@@ -25,12 +23,6 @@ class TokenCrossEntropyLoss(nn.Module):
         shift_labels = shift_labels.view(-1)
 
         return self.loss_fn(shift_logits, shift_labels)
-        # print(shift_logits.shape, shift_labels.shape)
-        loss = 0
-        for i in range(labels.shape[0]):
-            loss += self.loss_fn(shift_logits[i], shift_labels[i])
-        loss /= labels.shape[0]
-        return self.loss_fn(x, target)
 
 
 class SampleCrossEntropyLoss(nn.Module):

--- a/llm_studio/src/losses/classification_losses.py
+++ b/llm_studio/src/losses/classification_losses.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, List
 
-import torch
+from torch import nn
 
 __all__ = ["Losses"]
 

--- a/llm_studio/src/losses/classification_losses.py
+++ b/llm_studio/src/losses/classification_losses.py
@@ -11,100 +11,56 @@ from torch import nn
 logger = logging.getLogger(__name__)
 
 
-class DenseCrossEntropy(nn.Module):
+class TokenCrossEntropyLoss(nn.Module):
     def __init__(self, cfg: Any):
         super().__init__()
         self.cfg = cfg
+        self.loss_fn = nn.CrossEntropyLoss()
 
-    def forward(self, x, target):
-        x = x.float()
-        target = target.float()
-        logprobs = torch.nn.functional.log_softmax(x, dim=-1)
-        loss = -logprobs * target
-        loss = loss.sum(-1)
-        return loss.mean()
+    def forward(self, logits, labels):
+        shift_logits = logits[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
 
+        shift_logits = shift_logits.view(-1, shift_logits.size(-1))
+        shift_labels = shift_labels.view(-1)
 
-class BCEWithLogitsLoss(nn.Module):
-    def __init__(self, cfg: Any):
-        super().__init__()
-        self.cfg = cfg
-        self.loss_fn = nn.BCEWithLogitsLoss()
-
-    def forward(self, x, target):
+        return self.loss_fn(shift_logits, shift_labels)
+        # print(shift_logits.shape, shift_labels.shape)
+        loss = 0
+        for i in range(labels.shape[0]):
+            loss += self.loss_fn(shift_logits[i], shift_labels[i])
+        loss /= labels.shape[0]
         return self.loss_fn(x, target)
 
 
-class SigmoidFocalLoss(nn.Module):
-    """
-    Sigmoid focal loss for classification
-    Source: https://pytorch.org/vision/stable/_modules/torchvision/ops/focal_loss.html
-    """
-
-    def __init__(self, cfg: Any, gamma=2.0):
-        super().__init__()
-        self.cfg = cfg
-        self.gamma = gamma
-
-    def forward(self, x, target):
-        p = torch.sigmoid(x)
-        ce_loss = F.binary_cross_entropy_with_logits(x, target, reduction="none")
-        p_t = p * target + (1 - p) * (1 - target)
-        loss = ce_loss * ((1 - p_t) ** self.gamma)
-
-        # if self.alpha >= 0:
-        #     alpha_t = self.alpha * target + (1 - self.alpha) * (1 - target)
-        #     loss = alpha_t * loss
-
-        return loss.mean()
-
-
-class SoftmaxFocalLoss(nn.Module):
-    """
-    Softmax focal loss for classification
-    Source: https://discuss.pytorch.org/t/is-this-a-correct-implementation-for-focal-loss-in-pytorch/43327/8   # noqa
-    """
-
-    def __init__(self, cfg: Any, gamma=2.0):
-        super().__init__()
-        self.cfg = cfg
-        self.gamma = gamma
-
-    def forward(self, x, target):
-        log_prob = F.log_softmax(x, dim=-1)
-        prob = torch.exp(log_prob)
-        return F.nll_loss(
-            ((1 - prob) ** self.gamma) * log_prob,
-            target.argmax(dim=1),
-            reduction="mean",
-        )
-
-
-class ClassificationLoss(nn.modules.Module):
+class SampleCrossEntropyLoss(nn.Module):
     def __init__(self, cfg: Any):
         super().__init__()
-        if cfg.environment._local_rank == 0:
-            logger.info("Selecting BCE Loss.")
-        self.loss_fn = nn.BCEWithLogitsLoss()  # type: ignore
+        self.cfg = cfg
+        self.loss_fn = nn.CrossEntropyLoss()
 
-    def forward(self, x, target):
-        return self.loss_fn(x, target)
+    def forward(self, logits, labels):
+        shift_logits = logits[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+
+        loss = 0
+        for i in range(labels.shape[0]):
+            loss += self.loss_fn(shift_logits[i], shift_labels[i])
+        loss /= labels.shape[0]
+        return loss
 
 
 class Losses:
     """Losses factory."""
 
     _losses = {
-        "Classification": ClassificationLoss,
-        "BCE": BCEWithLogitsLoss,
-        "CrossEntropy": DenseCrossEntropy,
-        "SigmoidFocal": SigmoidFocalLoss,
-        "SoftmaxFocal": SoftmaxFocalLoss,
+        "TokenCrossEntropy": TokenCrossEntropyLoss,
+        "SampleCrossEntropy": SampleCrossEntropyLoss,
     }
 
     @classmethod
     def names(cls) -> List[str]:
-        return sorted(cls._losses.keys())
+        return cls._losses.keys()
 
     @classmethod
     def get(cls, name: str) -> Any:

--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -195,7 +195,6 @@ class Model(nn.Module):
             output = self.backbone(
                 input_ids=batch["input_ids"],
                 attention_mask=batch["attention_mask"],
-                labels=None,
             )
 
             if calculate_loss:

--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -114,7 +114,9 @@ class Model(nn.Module):
             self.backbone = get_peft_model(self.backbone, lora_config)
             self.backbone.print_trainable_parameters()
 
-        self.loss_fn = self.cfg.training.loss_class.get(self.cfg.training.loss_function)
+        self.loss_fn = self.cfg.training.loss_class.get(
+            self.cfg.training.loss_function
+        )(self.cfg)
 
     def generate(self, batch: Dict, cfg: Any):
         pad_token_id = (
@@ -193,11 +195,12 @@ class Model(nn.Module):
             output = self.backbone(
                 input_ids=batch["input_ids"],
                 attention_mask=batch["attention_mask"],
-                labels=batch["labels"],
+                labels=None,
             )
+
             if calculate_loss:
-                assert self.cfg.training.loss_function == "CrossEntropy"
-                outputs["loss"] = output.loss
+                loss = self.loss_fn(output.logits, batch["labels"])
+                outputs["loss"] = loss
 
         if not self.training:
             outputs["predicted_answer_ids"] = self.generate(batch, self.cfg)

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -488,11 +488,11 @@ def create_nlp_backbone(cfg, model_class=AutoModel, kwargs={}) -> Any:
     if cfg.architecture.gradient_checkpointing:
         config.use_cache = False
 
+    kwargs["trust_remote_code"] = cfg.environment.trust_remote_code
     if cfg.architecture.pretrained:
         backbone = model_class.from_pretrained(
             cfg.llm_backbone,
             config=config,
-            trust_remote_code=cfg.environment.trust_remote_code,
             quantization_config=quantization_config,
             **kwargs,
         )

--- a/tooltips/experiments/_limit_chained_samples.mdx
+++ b/tooltips/experiments/_limit_chained_samples.mdx
@@ -1,0 +1,1 @@
+If set to True, model will be only trained on the full chained sample in case of nested conversations. If set to False, each separate sample is used for training.


### PR DESCRIPTION
This PR addresses to points:

First, it introduces a new setting `limit_chained_samples` which limits the chained samples to the longest one. Please feel free to suggest a better name for that.

Second, it reworks loss calculation by adding functionality to calculate the loss in our code base instead of relying on the one in `transformers` model class. This will also allow us long-term more flexibility, in terms of adding new loss functions, weighted loss, etc.

For now, there are two BCE loss variations: 
- `TokenCrossEntropy` calculates the loss as before on token level
- `SampleCrossEntropy` calculates the loss separate per sample in a batch, and then averages per sample

Experiments seem to indiciate that in generel the old way works better.