### PR TITLE
switch back to default chat behaviour

### DIFF
--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -64,9 +64,8 @@ from llm_studio.src.utils.utils import add_file_to_zip, kill_child_processes
 
 logger = logging.getLogger(__name__)
 
-USER_ON_LEFT = False
-USER = USER_ON_LEFT
-BOT = not USER_ON_LEFT
+USER = True
+BOT = False
 
 
 async def experiment_start(q: Q) -> None:


### PR DESCRIPTION
With the new nightly build of wave, we can switch back to the intended usage for USER and BOT in the chat window

![image](https://github.com/h2oai/h2o-llmstudio/assets/1069138/fdc51050-a4b3-457d-8972-6bf12fea81be)
