### PR TITLE
enable train progress bar logging for sub 1 epoch evals

### DIFF
--- a/train.py
+++ b/train.py
@@ -214,27 +214,21 @@ def run_train(
         )
         if cfg.environment._local_rank == 0:
             logger.info(f"Training Epoch: {epoch + 1} / {cfg.training.epochs}")
-            if cfg.training.evaluation_epochs != 1:
-                logger.info(
-                    "Training progress bar is not "
-                    "displayed (evaluation epoch is not set to 1)"
-                )
 
         if cfg.environment._distributed and hasattr(
             train_dataloader.sampler, "set_epoch"
         ):
             train_dataloader.sampler.set_epoch(epoch)  # type: ignore
 
-        if cfg.training.evaluation_epochs == 1:
-            tqdm_out = TqdmToLogger(logger, level=logging.INFO)
-            progress_bar = tqdm(
-                total=epoch_steps,
-                disable=cfg.environment._local_rank != 0,
-                file=tqdm_out,
-                ascii=True,
-                desc="train loss",
-                mininterval=0,
-            )
+        tqdm_out = TqdmToLogger(logger, level=logging.INFO)
+        progress_bar = tqdm(
+            total=epoch_steps,
+            disable=cfg.environment._local_rank != 0,
+            file=tqdm_out,
+            ascii=True,
+            desc="train loss",
+            mininterval=0,
+        )
         tr_it = iter(train_dataloader)
 
         losses = []
@@ -343,9 +337,7 @@ def run_train(
                 )
 
                 # Show logs each 5% of the epoch (only if doing per epoch evaluation)
-                if cfg.training.evaluation_epochs == 1 and (
-                    (itr + 1) % log_update_steps == 0 or itr == epoch_steps - 1
-                ):
+                if (itr + 1) % log_update_steps == 0 or itr == epoch_steps - 1:
                     progress_bar.set_description(
                         f"train loss: {np.mean(losses[-10:]):.2f}", refresh=False
                     )
@@ -380,9 +372,8 @@ def run_train(
 
                 model.train()
 
-        if cfg.training.evaluation_epochs == 1:
-            progress_bar.close()
-            del progress_bar
+        progress_bar.close()
+        del progress_bar
 
         if cfg.environment._distributed:
             torch.cuda.synchronize(device=cfg.environment._local_rank)


### PR DESCRIPTION
I think, it's better to get a progress bar than nothing, especially when using CLI over GUI.


```
2023-06-14 22:28:39,507 - INFO: Global random seed: 66087
2023-06-14 22:28:39,507 - INFO: Preparing the data...
2023-06-14 22:28:39,560 - INFO: Preparing train and validation data
2023-06-14 22:28:39,560 - INFO: Loading train dataset...
2023-06-14 22:28:40,009 - INFO: Stop token ids: [tensor([41552, 15483, 27740, 15483, 15698]), tensor([41552, 15483, 12501, 3320, 15483, 15698])]
2023-06-14 22:28:40,036 - INFO: Sample prompt: <|prompt|>Can you write a short introduction about the relevance of the term "monopsony" in economics? Please use examples related to potential monopsonies in the labour market and cite relevant research
.<|answer|>
2023-06-14 22:28:40,036 - INFO: Loading validation dataset...
2023-06-14 22:28:40,404 - INFO: Stop token ids: [tensor([41552, 15483, 27740, 15483, 15698]), tensor([41552, 15483, 12501, 3320, 15483, 15698])]
2023-06-14 22:28:40,405 - WARNING: When using parent column, the dataframe requires an 'id' column. Disabling functionality for mode validation.
2023-06-14 22:28:40,405 - INFO: Sample prompt: <|prompt|>Write a short introduction to a blog about sustainable living.<|answer|>
2023-06-14 22:28:40,406 - INFO: Number of observations in train dataset: 8274
2023-06-14 22:28:40,406 - INFO: Number of observations in validation dataset: 50
2023-06-14 22:28:40,542 - INFO: Using float16 for backbone
2023-06-14 22:28:41,983 - INFO: Training Epoch: 1 / 1
2023-06-14 22:28:41,983 - INFO: train loss: 0%| | 0/2758 [00:00
2023-06-14 22:28:42,507 - INFO: Stop token ids: [tensor([41552, 15483, 27740, 15483, 15698]), tensor([41552, 15483, 12501, 3320, 15483, 15698])]
2023-06-14 22:28:50,681 - INFO: train loss: 2.54: 5%|4 | 137/2758 [00:08<02:46, 15.75it/s]
2023-06-14 22:28:58,155 - INFO: train loss: 2.52: 10%|9 | 274/2758 [00:16<02:24, 17.17it/s]
2023-06-14 22:29:05,462 - INFO: train loss: 2.41: 15%|#4 | 411/2758 [00:23<02:11, 17.86it/s]
2023-06-14 22:29:12,897 - INFO: train loss: 2.46: 20%|#9 | 548/2758 [00:30<02:02, 18.08it/s]
2023-06-14 22:29:20,325 - INFO: train loss: 2.61: 25%|##4 | 685/2758 [00:38<01:53, 18.21it/s]
2023-06-14 22:29:20,528 - INFO: Starting validation inference
2023-06-14 22:29:20,529 - INFO: validation progress: 0%| | 0/17 [00:00
2023-06-14 22:29:27,060 - INFO: validation progress: 6%|5 | 1/17 [00:06<01:44, 6.53s/it]
2023-06-14 22:29:31,984 - INFO: train loss: 2.61: 25%|##4 | 685/2758 [00:50<01:53, 18.21it/s]
2023-06-14 22:29:33,173 - INFO: validation progress: 12%|#1 | 2/17 [00:12<01:34, 6.29s/it]
2023-06-14 22:29:39,208 - INFO: validation progress: 18%|#7 | 3/17 [00:18<01:26, 6.17s/it]
2023-06-14 22:29:45,226 - INFO: validation progress: 24%|##3 | 4/17 [00:24<01:19, 6.11s/it]
2023-06-14 22:29:51,205 - INFO: validation progress: 29%|##9 | 5/17 [00:30<01:12, 6.06s/it]
2023-06-14 22:29:57,451 - INFO: validation progress: 35%|###5 | 6/17 [00:36<01:07, 6.13s/it]
2023-06-14 22:30:03,494 - INFO: validation progress: 41%|####1 | 7/17 [00:42<01:00, 6.10s/it]
2023-06-14 22:30:09,510 - INFO: validation progress: 47%|####7 | 8/17 [00:48<00:54, 6.07s/it]
2023-06-14 22:30:15,525 - INFO: validation progress: 53%|#####2 | 9/17 [00:54<00:48, 6.05s/it]
2023-06-14 22:30:21,544 - INFO: validation progress: 59%|#####8 | 10/17 [01:01<00:42, 6.04s/it]
2023-06-14 22:30:27,633 - INFO: validation progress: 65%|######4 | 11/17 [01:07<00:36, 6.06s/it]
2023-06-14 22:30:34,055 - INFO: validation progress: 71%|####### | 12/17 [01:13<00:30, 6.17s/it]
2023-06-14 22:30:40,472 - INFO: validation progress: 76%|#######6 | 13/17 [01:19<00:24, 6.24s/it]
2023-06-14 22:30:47,032 - INFO: validation progress: 82%|########2 | 14/17 [01:26<00:19, 6.34s/it]
2023-06-14 22:30:53,282 - INFO: validation progress: 88%|########8 | 15/17 [01:32<00:12, 6.31s/it]
2023-06-14 22:30:59,518 - INFO: validation progress: 94%|#########4| 16/17 [01:38<00:06, 6.29s/it]
2023-06-14 22:31:04,516 - INFO: validation progress: 100%|##########| 17/17 [01:43<00:00, 5.90s/it]
2023-06-14 22:31:04,518 - INFO: validation progress: 100%|##########| 17/17 [01:43<00:00, 6.12s/it]
2023-06-14 22:31:04,603 - INFO: GPT eval: 0%| | 0/50 [00:00
2023-06-14 22:31:05,058 - INFO: GPT eval: 2%|2 | 1/50 [00:00<00:22, 2.20it/s]
2023-06-14 22:31:08,053 - INFO: GPT eval: 32%|###2 | 16/50 [00:03<00:07, 4.74it/s]
2023-06-14 22:31:11,199 - INFO: GPT eval: 48%|####8 | 24/50 [00:06<00:07, 3.48it/s]
2023-06-14 22:31:16,473 - INFO: GPT eval: 64%|######4 | 32/50 [00:11<00:07, 2.34it/s]
2023-06-14 22:31:22,285 - INFO: GPT eval: 80%|######## | 40/50 [00:17<00:05, 1.88it/s]
2023-06-14 22:31:27,876 - INFO: GPT eval: 96%|#########6| 48/50 [00:23<00:01, 1.70it/s]
2023-06-14 22:31:27,876 - INFO: GPT eval: 100%|##########| 50/50 [00:23<00:00, 2.15it/s]
2023-06-14 22:32:04,734 - INFO: Mean validation loss: 2.22774
2023-06-14 22:32:04,735 - INFO: Validation GPT3.5: 0.10500
2023-06-14 22:32:11,881 - INFO: train loss: 2.42: 30%|##9 | 822/2758 [03:29<14:54, 2.16it/s]
2023-06-14 22:32:19,195 - INFO: train loss: 2.52: 35%|###4 | 959/2758 [03:37<09:50, 3.04it/s]
2023-06-14 22:32:31,988 - INFO: train loss: 2.32: 40%|###9 | 1096/2758 [03:50<09:05, 3.04it/s]
2023-06-14 22:32:33,896 - INFO: train loss: 2.56: 45%|####4 | 1233/2758 [03:51<04:58, 5.11it/s]
2023-06-14 22:32:41,593 - INFO: Starting validation inference
2023-06-14 22:32:41,593 - INFO: validation progress: 0%| | 0/17 [00:00
2023-06-14 22:32:47,904 - INFO: validation progress: 6%|5 | 1/17 [00:06<01:40, 6.31s/it]
2023-06-14 22:32:51,989 - INFO: train loss: 2.51: 50%|####9 | 1370/2758 [04:10<04:31, 5.11it/s]
2023-06-14 22:32:54,261 - INFO: validation progress: 12%|#1 | 2/17 [00:12<01:35, 6.34s/it]
2023-06-14 22:33:00,316 - INFO: validation progress: 18%|#7 | 3/17 [00:18<01:26, 6.21s/it]
2023-06-14 22:33:06,424 - INFO: validation progress: 24%|##3 | 4/17 [00:24<01:20, 6.17s/it]
2023-06-14 22:33:12,688 - INFO: validation progress: 29%|##9 | 5/17 [00:31<01:14, 6.20s/it]
2023-06-14 22:33:18,650 - INFO: validation progress: 35%|###5 | 6/17 [00:37<01:07, 6.12s/it]
2023-06-14 22:33:24,914 - INFO: validation progress: 41%|####1 | 7/17 [00:43<01:01, 6.17s/it]
2023-06-14 22:33:31,719 - INFO: validation progress: 47%|####7 | 8/17 [00:50<00:57, 6.37s/it]
2023-06-14 22:33:37,797 - INFO: validation progress: 53%|#####2 | 9/17 [00:56<00:50, 6.28s/it]
2023-06-14 22:33:43,686 - INFO: validation progress: 59%|#####8 | 10/17 [01:02<00:43, 6.16s/it]
2023-06-14 22:33:50,508 - INFO: validation progress: 65%|######4 | 11/17 [01:08<00:38, 6.36s/it]
2023-06-14 22:33:57,000 - INFO: validation progress: 71%|####### | 12/17 [01:15<00:32, 6.40s/it]
2023-06-14 22:34:03,866 - INFO: validation progress: 76%|#######6 | 13/17 [01:22<00:26, 6.54s/it]
2023-06-14 22:34:10,306 - INFO: validation progress: 82%|########2 | 14/17 [01:28<00:19, 6.51s/it]
2023-06-14 22:34:16,381 - INFO: validation progress: 88%|########8 | 15/17 [01:34<00:12, 6.38s/it]
2023-06-14 22:34:22,510 - INFO: validation progress: 94%|#########4| 16/17 [01:40<00:06, 6.30s/it]
2023-06-14 22:34:27,276 - INFO: validation progress: 100%|##########| 17/17 [01:45<00:00, 5.84s/it]
2023-06-14 22:34:27,278 - INFO: validation progress: 100%|##########| 17/17 [01:45<00:00, 6.22s/it]
2023-06-14 22:34:27,354 - INFO: GPT eval: 0%| | 0/50 [00:00
2023-06-14 22:34:27,755 - INFO: GPT eval: 2%|2 | 1/50 [00:00<00:19, 2.50it/s]
2023-06-14 22:34:30,762 - INFO: GPT eval: 32%|###2 | 16/50 [00:03<00:07, 4.78it/s]
2023-06-14 22:34:34,550 - INFO: GPT eval: 48%|####8 | 24/50 [00:07<00:08, 3.12it/s]
2023-06-14 22:34:38,912 - INFO: GPT eval: 64%|######4 | 32/50 [00:11<00:07, 2.47it/s]
2023-06-14 22:34:42,707 - INFO: GPT eval: 80%|######## | 40/50 [00:15<00:04, 2.33it/s]
2023-06-14 22:34:47,665 - INFO: GPT eval: 96%|#########6| 48/50 [00:20<00:00, 2.03it/s]
2023-06-14 22:34:47,666 - INFO: GPT eval: 100%|##########| 50/50 [00:20<00:00, 2.46it/s]
2023-06-14 22:34:56,390 - INFO: Mean validation loss: 2.20996
2023-06-14 22:34:56,392 - INFO: Validation GPT3.5: 0.10600
2023-06-14 22:35:03,662 - INFO: train loss: 2.53: 55%|#####4 | 1507/2758 [06:21<07:04, 2.95it/s]
2023-06-14 22:35:11,067 - INFO: train loss: 2.49: 60%|#####9 | 1644/2758 [06:29<05:05, 3.64it/s]
...
```