### PR TITLE
fix style command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ style: reports pipenv
 	@echo
 
 	-$(PIPENV) run flake8 | tee -a reports/flake8_errors.log
-	-$(PIPENV) run mypy . --check-untyped-defs | tee -a reports/mypy.log || echo "mypy failed" >> reports/mypy_errors.log
-
 	@if [ -s reports/flake8_errors.log ]; then exit 1; fi
+
+	-$(PIPENV) run mypy . --check-untyped-defs | tee -a reports/mypy.log || echo "mypy failed" >> reports/mypy_errors.log
 	@if [ -s reports/mypy_errors.log ]; then exit 1; fi
 
 .PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -40,20 +40,16 @@ reports:
 
 .PHONY: style
 style: reports pipenv
-	@echo -n > reports/style.log
-	@echo -n > reports/style_errors.log
+	@echo -n > reports/flake8_errors.log
+	@echo -n > reports/mypy_errors.log
+	@echo -n > reports/mypy.log
 	@echo
 
-	@echo "# flake8" >> reports/style.log
-	-$(PIPENV) run flake8 | tee -a reports/style.log || echo "flake8 failed" >> reports/style_errors.log
-	@echo
+	-$(PIPENV) run flake8 | tee -a reports/flake8_errors.log
+	-$(PIPENV) run mypy . --check-untyped-defs | tee -a reports/mypy.log || echo "mypy failed" >> reports/mypy_errors.log
 
-	@echo "" >> reports/style.log
-	@echo "# mypy" >> reports/style.log
-	-$(PIPENV) run mypy . --check-untyped-defs | tee -a reports/style.log || echo "mypy failed" >> reports/style_errors.log
-	@echo
-
-	@if [ -s reports/style_errors.log ]; then exit 1; fi
+	@if [ -s reports/flake8_errors.log ]; then exit 1; fi
+	@if [ -s reports/mypy_errors.log ]; then exit 1; fi
 
 .PHONY: format
 format: pipenv

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -319,7 +319,7 @@ class CustomDataset(Dataset):
         encodings = parent_encodings + encodings
 
         sample["reward_model_prompt_text"] = (
-                reward_model_parent_prompt_text + self.raw_prompts[idx]
+            reward_model_parent_prompt_text + self.raw_prompts[idx]
         )
 
         input_ids = torch.cat([torch.cat(encoding) for encoding in encodings])
@@ -344,10 +344,10 @@ class CustomDataset(Dataset):
                 labels[-1] = self.tokenizer.eos_token_id
 
             if self.cfg.tokenizer.max_length < len(input_ids):
-                labels = labels[-self.cfg.tokenizer.max_length:]
+                labels = labels[-self.cfg.tokenizer.max_length :]
 
             sample["labels"] = torch.full((self.cfg.tokenizer.max_length,), -100)
-            sample["labels"][-len(labels):] = labels
+            sample["labels"][-len(labels) :] = labels
 
         sample.update(
             self.pad_tokens(


### PR DESCRIPTION
Fixes a `make style` issue I overlooked when reviewing [pp/typing](https://github.com/h2oai/h2o-llmstudio/pull/173) PR.

`$(PIPENV) run flake8` will never fail upon errors, but log them. Hence, the  command
`-$(PIPENV) run flake8 | tee -a reports/style.log || echo "flake8 failed" >> reports/style_errors.log`
 does not work as expected.