### PR TITLE
Fix auth token for falcon models

### DIFF
--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -34,14 +34,26 @@ def get_tokenizer(cfg: Any):
     if "llama" in cfg.llm_backbone:
         logger.info("Llama backbone detected, forcing slow tokenizer.")
         cfg.tokenizer.use_fast = False
-    tokenizer = AutoTokenizer.from_pretrained(
-        cfg.llm_backbone,
+
+    kwargs = dict(
         revision=cfg.environment.huggingface_branch,
         add_prefix_space=cfg.tokenizer.add_prefix_space,
         use_fast=cfg.tokenizer.use_fast,
         trust_remote_code=cfg.environment.trust_remote_code,
         use_auth_token=os.getenv("HUGGINGFACE_TOKEN"),
     )
+
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(
+            cfg.llm_backbone,
+        )
+    except TypeError:
+        # TypeError: RWForCausalLM.__init__() got an unexpected keyword argument 'use_auth_token'
+        # Will potentially be fixed in transformers library directly
+        kwargs.pop("use_auth_token")
+        tokenizer = AutoTokenizer.from_pretrained(
+            cfg.llm_backbone,
+        )
     tokenizer.padding_side = getattr(
         cfg.tokenizer, "_padding_side", tokenizer.padding_side
     )

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -44,16 +44,12 @@ def get_tokenizer(cfg: Any):
     )
 
     try:
-        tokenizer = AutoTokenizer.from_pretrained(
-            cfg.llm_backbone,
-        )
+        tokenizer = AutoTokenizer.from_pretrained(cfg.llm_backbone, **kwargs)
     except TypeError:
-        # TypeError: RWForCausalLM.__init__() got an unexpected keyword argument 'use_auth_token'
-        # Will potentially be fixed in transformers library directly
+        # TypeError: RWForCausalLM.__init__() got
+        # an unexpected keyword argument 'use_auth_token'
         kwargs.pop("use_auth_token")
-        tokenizer = AutoTokenizer.from_pretrained(
-            cfg.llm_backbone,
-        )
+        tokenizer = AutoTokenizer.from_pretrained(cfg.llm_backbone, **kwargs)
     tokenizer.padding_side = getattr(
         cfg.tokenizer, "_padding_side", tokenizer.padding_side
     )

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -491,6 +491,7 @@ def create_nlp_backbone(cfg, model_class=AutoModel, kwargs=None) -> Any:
             **kwargs,
         )
     else:
+        kwargs.pop("use_auth_token", None)
         backbone = model_class.from_config(config, **kwargs)
 
     if cfg.tokenizer._vocab_length > config.vocab_size:

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -445,8 +445,8 @@ def create_nlp_backbone(cfg, model_class=AutoModel, kwargs=None) -> Any:
         )
         kwargs["use_auth_token"] = os.getenv("HUGGINGFACE_TOKEN")
     except TypeError:
-        # TypeError: RWForCausalLM.__init__() got an unexpected keyword argument 'use_auth_token'
-        # Will potentially be fixed in transformers library directly
+        # TypeError: RWForCausalLM.__init__() got
+        # an unexpected keyword argument 'use_auth_token'
         config = AutoConfig.from_pretrained(
             cfg.llm_backbone,
             trust_remote_code=cfg.environment.trust_remote_code,

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -434,12 +434,21 @@ def create_nlp_backbone(cfg, model_class=AutoModel, kwargs={}) -> Any:
     Creates a backbone model for NLP tasks.
     This is needed for Gradient Checkpointing in DDP mode.
     """
-    config = AutoConfig.from_pretrained(
-        cfg.llm_backbone,
-        trust_remote_code=cfg.environment.trust_remote_code,
-        use_auth_token=os.getenv("HUGGINGFACE_TOKEN"),
-        revision=cfg.environment.huggingface_branch,
-    )
+    try:
+        config = AutoConfig.from_pretrained(
+            cfg.llm_backbone,
+            trust_remote_code=cfg.environment.trust_remote_code,
+            use_auth_token=os.getenv("HUGGINGFACE_TOKEN"),
+            revision=cfg.environment.huggingface_branch,
+        )
+    except TypeError:
+        # TypeError: RWForCausalLM.__init__() got an unexpected keyword argument 'use_auth_token'
+        # Will potentially be fixed in transformers library directly
+        config = AutoConfig.from_pretrained(
+            cfg.llm_backbone,
+            trust_remote_code=cfg.environment.trust_remote_code,
+            revision=cfg.environment.huggingface_branch,
+        )
     config.hidden_dropout_prob = cfg.architecture.intermediate_dropout
     config.attention_probs_dropout_prob = cfg.architecture.intermediate_dropout
 


### PR DESCRIPTION
Hotfix for PR #167.

Use auth token argument is incompatible with falcon models, as their model/config/tokenizer class are missing this argument in their init. Thus, falcon models are currently failing on main.