### PR TITLE
Refactoring

### DIFF
--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -138,7 +138,9 @@ class Model(nn.Module):
             logger.warning("Forcing LoRA to be True for RLHF")
             cfg.training.lora = True
 
-        self.backbone, self.backbone_config = create_nlp_backbone(cfg, model_class=AutoModelForCausalLM)
+        self.backbone, self.backbone_config = create_nlp_backbone(
+            cfg, model_class=AutoModelForCausalLM
+        )
 
         if cfg.training.lora:
             self.prepare_lora()

--- a/llm_studio/src/models/text_causal_language_modeling_model.py
+++ b/llm_studio/src/models/text_causal_language_modeling_model.py
@@ -138,9 +138,7 @@ class Model(nn.Module):
             logger.warning("Forcing LoRA to be True for RLHF")
             cfg.training.lora = True
 
-        self.backbone, self.backbone_config = create_nlp_backbone(
-            cfg, model_class=AutoModelForCausalLM
-        )
+        self.backbone, self.backbone_config = create_nlp_backbone(cfg, model_class=AutoModelForCausalLM)
 
         if cfg.training.lora:
             self.prepare_lora()

--- a/llm_studio/src/trl/trainer.py
+++ b/llm_studio/src/trl/trainer.py
@@ -566,7 +566,6 @@ class PPOTrainer(PyTorchModelHubMixin):
                 outputs = model(
                     model_inputs_batch,
                     padding=False,
-                    generate=False,
                 )
 
             logits = outputs["logits"]

--- a/llm_studio/src/utils/config_utils.py
+++ b/llm_studio/src/utils/config_utils.py
@@ -109,7 +109,9 @@ def convert_cfg_to_nested_dictionary(cfg: ConfigProblemBase) -> dict:
             continue
 
         if any([x in k for x in ["api", "secret"]]):
-            raise AssertionError("Config item must not contain the word 'api' or 'secret'")
+            raise AssertionError(
+                "Config item must not contain the word 'api' or 'secret'"
+            )
 
         type_annotation = type_annotations[k]
 

--- a/llm_studio/src/utils/config_utils.py
+++ b/llm_studio/src/utils/config_utils.py
@@ -108,8 +108,8 @@ def convert_cfg_to_nested_dictionary(cfg: ConfigProblemBase) -> dict:
         if k.startswith("_"):
             continue
 
-        if any([x in k for x in ["api"]]):
-            continue
+        if any([x in k for x in ["api", "secret"]]):
+            raise AssertionError("Config item must not contain the word 'api' or 'secret'")
 
         type_annotation = type_annotations[k]
 

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -432,13 +432,12 @@ def save_predictions(cfg, val_data, val_dataloader, val_df, mode):
     val_df.to_csv(csv_preds_name, index=False)
 
 
-def create_nlp_backbone(cfg, model_class=AutoModel, kwargs=None) -> Any:
+def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
     """
     Creates a backbone model for NLP tasks.
     This is needed for Gradient Checkpointing in DDP mode.
     """
-    if kwargs is None:
-        kwargs = {}
+    kwargs = {}
     try:
         config = AutoConfig.from_pretrained(
             cfg.llm_backbone,

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -437,7 +437,7 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
     Creates a backbone model for NLP tasks.
     This is needed for Gradient Checkpointing in DDP mode.
     """
-    kwargs = {}
+    kwargs = dict()
     try:
         config = AutoConfig.from_pretrained(
             cfg.llm_backbone,
@@ -459,16 +459,16 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
 
     quantization_config = None
     if cfg.architecture.backbone_dtype == "int8":
-        kwargs["device_map"] = {"": cfg.environment._device}
+        kwargs["device_map"] = {"": cfg.environment._device}  # type: ignore
         quantization_config = BitsAndBytesConfig(
             load_in_8bit=True,
             llm_int8_threshold=0.0,
         )
         # need to force pretrained
         cfg.architecture.pretrained = True
-        kwargs["torch_dtype"] = torch.float16
+        kwargs["torch_dtype"] = torch.float16  # type: ignore
     elif cfg.architecture.backbone_dtype == "int4":
-        kwargs["device_map"] = {"": cfg.environment._device}
+        kwargs["device_map"] = {"": cfg.environment._device}  # type: ignore
         quantization_config = BitsAndBytesConfig(
             load_in_4bit=True,
             bnb_4bit_compute_dtype=torch.float16,
@@ -476,7 +476,7 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
         )
         # need to force pretrained
         cfg.architecture.pretrained = True
-        kwargs["torch_dtype"] = torch.float16
+        kwargs["torch_dtype"] = torch.float16  # type: ignore
     else:
         kwargs["torch_dtype"] = getattr(torch, cfg.architecture.backbone_dtype)
 

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -366,7 +366,11 @@ def run_inference(
         batch = cfg.dataset.dataset_class.batch_to_device(data, cfg.environment._device)
 
         with autocast(enabled=cfg.environment.mixed_precision):
-            output = model.forward(batch, generate=True)
+            output = model.forward(batch)
+            if cfg.prediction.metric != "Perplexity":
+                output["predicted_answer_ids"] = (
+                    model.generate(batch, cfg).detach().cpu()
+                )
         if contains_nan(output) and cfg.environment.mixed_precision:
             raise LLMModelException(
                 "NaN caught during mixed precision inference. "

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -369,7 +369,7 @@ def run_inference(
             output = model.forward(batch)
             if cfg.prediction.metric != "Perplexity":
                 output["predicted_answer_ids"] = (
-                    model.generate(batch, cfg).detach().cpu()
+                    unwrap_model(model).generate(batch, cfg).detach().cpu()
                 )
         if contains_nan(output) and cfg.environment.mixed_precision:
             raise LLMModelException(

--- a/train.py
+++ b/train.py
@@ -338,7 +338,7 @@ def run_train(
                     output_dict = model.forward(batch)
 
                 loss = output_dict["loss"]
-                if ~np.isfinite(loss.item()) and (itr > 20):
+                if ~np.isfinite(loss.item()) and (epoch > start_epoch or itr > 20):
                     raise LLMTrainingException(
                         "NaN caught in loss during training. "
                         "Please, reduce learning rate, change dtype, "

--- a/train.py
+++ b/train.py
@@ -202,8 +202,6 @@ def run_train(
         best_val_metric = np.inf
         objective_op = np.less
 
-    num_updates = 0
-
     if cfg.training.evaluate_before_training:
         val_loss, val_metric = run_eval(
             cfg=cfg, model=model, val_dataloader=val_dataloader, val_df=val_df
@@ -251,14 +249,10 @@ def run_train(
 
         log_update_steps = max(epoch_steps // 20, 1)
         evaluation_step = int(epoch_steps * cfg.training.evaluation_epochs)
-        for itr in range(epoch_steps):
-            num_updates += 1
+        for itr, data in enumerate(tr_it):
             cfg.environment._curr_step += (
                 cfg.training.batch_size * cfg.environment._world_size
             )
-
-            # Get batch
-            data = next(tr_it)
 
             # Batch to device
             batch = cfg.dataset.dataset_class.batch_to_device(
@@ -341,10 +335,10 @@ def run_train(
             else:
                 # Forward pass
                 with autocast(enabled=cfg.environment.mixed_precision):
-                    output_dict = model.forward(batch, generate=False)
+                    output_dict = model.forward(batch)
 
                 loss = output_dict["loss"]
-                if ~np.isfinite(loss.item()) and (num_updates > 20):
+                if ~np.isfinite(loss.item()) and (itr > 20):
                     raise LLMTrainingException(
                         "NaN caught in loss during training. "
                         "Please, reduce learning rate, change dtype, "
@@ -363,7 +357,7 @@ def run_train(
                 # Backward pass
                 if cfg.environment.mixed_precision:
                     scaler.scale(loss).backward()  # type: ignore
-                    if num_updates % cfg.training.grad_accumulation == 0:
+                    if itr % cfg.training.grad_accumulation == 0:
                         if cfg.training.gradient_clip > 0:
                             scaler.unscale_(optimizer)  # type: ignore
                             torch.nn.utils.clip_grad_norm_(
@@ -374,7 +368,7 @@ def run_train(
                         optimizer.zero_grad(set_to_none=True)
                 else:
                     loss.backward()
-                    if num_updates % cfg.training.grad_accumulation == 0:
+                    if itr % cfg.training.grad_accumulation == 0:
                         if cfg.training.gradient_clip > 0:
                             torch.nn.utils.clip_grad_norm_(
                                 model.parameters(), cfg.training.gradient_clip


### PR DESCRIPTION
Some light refactoring/cleanup.

- clean `.generate` method; model always gets `"prompt_input_ids"`
- move `.generate` method out of forward call in favor of calling it directly during evaluation
- raise an explicit error if config contains the words api or secret to prevent unexpected behavior when copying the config.
- Remove `num_updates` and `next(tr_iter)` in favor of enumeration loop. Refactored implementation does not 100% reproduce the original logic, as `num_updates` is tracked globally across all epochs, while `itr` is reset to 0 after each epoch. FAPP, this should not make a difference as it only is used in mod operations to check gradient accumulation updates.