### PR TITLE
Def loss in dictionary

### DIFF
--- a/llm_studio/src/losses/text_causal_language_modeling_losses.py
+++ b/llm_studio/src/losses/text_causal_language_modeling_losses.py
@@ -63,4 +63,4 @@ class Losses:
         Returns:
             A class to build the Losses
         """
-        return cls._losses.get(name)
+        return cls._losses.get(name, TokenAveragedCrossEntropyLoss)


### PR DESCRIPTION
Specifying a default loss, this is for migration reasons after we rename loss functions.