### PR TITLE
[WIP] support for pytorch mps (metal/macos)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PWD = $(shell pwd)
 PHONY: pipenv
 pipenv:
 	$(PIP) install pip --upgrade
-	$(PIP) install pipenv==2022.10.4
+	$(PIP) install pipenv==2022.10.25
 
 .PHONY: setup
 setup: pipenv

--- a/Pipfile
+++ b/Pipfile
@@ -4,17 +4,25 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [[source]]
-name = "pytorch"
+name = "pytorch-cuda"
 url = "https://download.pytorch.org/whl/cu117"
+verify_ssl = false
+
+[[source]]
+name = "pytorch-mps"
+url = "https://download.pytorch.org/whl/nightly/cpu"
 verify_ssl = false
 
 [requires]
 python_version = "3.10"
 
 [packages]
-torch = {index = "pytorch", version = "==2.0.0+cu117"}
-torchvision = {index = "pytorch", version = "==0.15.1+cu117"}
-torchaudio = {index = "pytorch", version = "==2.0.1+cu117"}
+torch = {index = "pytorch-cuda", version = "==2.0.0+cu117"}
+torchvision = {index = "pytorch-cuda", version = "==0.15.1+cu117"}
+torchaudio = {index = "pytorch-cuda", version = "==2.0.1+cu117"}
+#torch = {index = "pytorch-mps", version = "==2.1.0.dev20230630", sys_platform = "== 'darwin'"}
+#torchvision = {index = "pytorch-mps", version = "==0.16.0.dev20230630", sys_platform = "== 'darwin'"}
+#torchaudio = {index = "pytorch-mps", version = "==2.1.0.dev20230630", sys_platform = "== 'darwin'"}
 tqdm = ">=4.65.0, <5.0.0"
 transformers = "==4.30.1"
 numpy = ">=1.23.2, <2.0.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "523dde3cf862e0310b13b878e9b5a0d08670c1c584c549811a50a36a3e9c06fd"
+            "sha256": "ae6e9a721edca70db5dd4abba4c5ea7e124bdbf2d9d0e4840468299cb17a36ca"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -14,8 +14,13 @@
                 "verify_ssl": true
             },
             {
-                "name": "pytorch",
+                "name": "pytorch-cuda",
                 "url": "https://download.pytorch.org/whl/cu117",
+                "verify_ssl": false
+            },
+            {
+                "name": "pytorch-mps",
+                "url": "https://download.pytorch.org/whl/nightly/cpu",
                 "verify_ssl": false
             }
         ]
@@ -2115,7 +2120,7 @@
                 "sha256:f0b525686f25c30e1de87d0fbdcd0b373f4c70a0f72bd854389e601a52fdc5e5",
                 "sha256:f6e26492d214edab5b407e903ed3c7b190ac5709330bd72060d1be01b354c198"
             ],
-            "index": "pytorch",
+            "index": "pytorch-cuda",
             "version": "==2.0.0+cu117"
         },
         "torchaudio": {
@@ -2129,7 +2134,7 @@
                 "sha256:e37a556d036f48a4f4f33fe698f844024037ece66123bf21715de73e506cdec3",
                 "sha256:f8fc84a567e307c8d05742ca713240c43cd67842632f6b231adf3fcffd812f37"
             ],
-            "index": "pytorch",
+            "index": "pytorch-cuda",
             "version": "==2.0.1+cu117"
         },
         "torchvision": {
@@ -2143,7 +2148,7 @@
                 "sha256:6d82ede144cabe85f21814c723b3a666d427de9566056701863663ea0f2ad7d9",
                 "sha256:a9bff1003aae1019f672996ebee62438f83843498926733d6f2f378314ad8326"
             ],
-            "index": "pytorch",
+            "index": "pytorch-cuda",
             "version": "==0.15.1+cu117"
         },
         "tornado": {

--- a/examples/cfg_example_oasst1.py
+++ b/examples/cfg_example_oasst1.py
@@ -1,3 +1,4 @@
+import torch
 from dataclasses import dataclass
 
 from llm_studio.python_configs.text_causal_language_modeling_config import (
@@ -49,7 +50,7 @@ class Config(ConfigProblemBase):
         token_mask_probability=0.0
     )
     architecture: ConfigNLPCausalLMArchitecture = ConfigNLPCausalLMArchitecture(
-        backbone_dtype="float16",
+        backbone_dtype="float32" if torch.backends.mps.is_available() else "float16",
     )
     training: ConfigNLPCausalLMTraining = ConfigNLPCausalLMTraining(
         optimizer="AdamW",
@@ -75,6 +76,7 @@ class Config(ConfigProblemBase):
         stop_tokens="",
     )
     environment: ConfigNLPCausalLMEnvironment = ConfigNLPCausalLMEnvironment(
-        mixed_precision=True, number_of_workers=8, seed=1
+        mixed_precision=False if torch.backends.mps.is_available() else True,
+        number_of_workers=8, seed=1
     )
     logging: ConfigNLPCausalLMLogging = ConfigNLPCausalLMLogging()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -i https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu117
+--extra-index-url https://download.pytorch.org/whl/nightly/cpu
 accelerate==0.20.3
 aiohttp==3.8.4 ; python_version >= '3.6'
 aiosignal==1.3.1 ; python_version >= '3.7'


### PR DESCRIPTION
with these PR, (once I uncomment pytorch-mps entries in `Pipfile`), I can run `make setup`, `make wave` and `train.py` successfully on macOS.

```
$ python3.10 -m pipenv run python train.py -C examples/cfg_example_oasst1.py
                                                                                                                           
===================================BUG REPORT===================================                                           
Welcome to bitsandbytes. For bug reports, please run                                                                       
                                                                                                                           
python -m bitsandbytes                                                                                                     
                                                                                                                           
 and submit this information together with your error trace to: https://github.com/TimDettmers/bitsandbytes/issues         
================================================================================                                           
bin /Users/tmm1/.local/share/virtualenvs/h2o-llmstudio-kx1PJ3DV/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_c
pu.so                                                                                                                      
/Users/tmm1/.local/share/virtualenvs/h2o-llmstudio-kx1PJ3DV/lib/python3.10/site-packages/bitsandbytes/cextension.py:34: Use
rWarning: The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, a
nd GPU quantization are unavailable.                                                                                       
  warn("The installed version of bitsandbytes was compiled without GPU support. "                                          
'NoneType' object has no attribute 'cadam32bit_grad_fp32'                                                                  
CUDA SETUP: Loading binary /Users/tmm1/.local/share/virtualenvs/h2o-llmstudio-kx1PJ3DV/lib/python3.10/site-packages/bitsand
bytes/libbitsandbytes_cpu.so...                                                                                            
dlopen(/Users/tmm1/.local/share/virtualenvs/h2o-llmstudio-kx1PJ3DV/lib/python3.10/site-packages/bitsandbytes/libbitsandbyte
s_cpu.so, 0x0006): tried: '/Users/tmm1/.local/share/virtualenvs/h2o-llmstudio-kx1PJ3DV/lib/python3.10/site-packages/bitsand
bytes/libbitsandbytes_cpu.so' (not a mach-o file), '/System/Volumes/Preboot/Cryptexes/OS/Users/tmm1/.local/share/virtualenv
s/h2o-llmstudio-kx1PJ3DV/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so' (no such file), '/Users/tmm1/.lo
cal/share/virtualenvs/h2o-llmstudio-kx1PJ3DV/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so' (not a mach-
o file)                                                                                                                    
2023-06-30 13:30:45,198 - INFO: Global random seed: 1                                                                      
2023-06-30 13:30:45,199 - INFO: Preparing the data...                                                                      
2023-06-30 13:30:45,199 - INFO: Setting up automatic validation split...                                                   
2023-06-30 13:30:45,286 - INFO: Preparing train and validation data                                                        
2023-06-30 13:30:45,286 - INFO: Loading train dataset...                                                                   
Using pad_token, but it is not set yet.                                                                                    
Using cls_token, but it is not set yet.                                                                                    
Using sep_token, but it is not set yet.                                                                                    
2023-06-30 13:30:45,735 - INFO: Stop token ids: []                                                                         
2023-06-30 13:30:45,763 - INFO: Sample prompt: Can you make it about 50% shorter and more exciting? Think to a dynamic tv a
dvertisement for sport product<|endoftext|>                                                                                
2023-06-30 13:30:45,763 - INFO: Loading validation dataset...                                                              
Using pad_token, but it is not set yet.                                                                                    
Using cls_token, but it is not set yet.                                                                                    
Using sep_token, but it is not set yet.                                     
2023-06-30 13:30:45,735 - INFO: Stop token ids: []                                                                         
2023-06-30 13:30:45,763 - INFO: Sample prompt: Can you make it about 50% shorter and more exciting? Think to a dynamic tv a
dvertisement for sport product<|endoftext|>                                                                                
2023-06-30 13:30:45,763 - INFO: Loading validation dataset...                                                              
Using pad_token, but it is not set yet.                                                                                    
Using cls_token, but it is not set yet.                                                                                    
Using sep_token, but it is not set yet.                                                                                    
2023-06-30 13:30:46,060 - INFO: Stop token ids: []                                                                         
2023-06-30 13:30:46,061 - INFO: Sample prompt: What types of tests do we have in software development?<|endoftext|>        
2023-06-30 13:30:46,061 - INFO: Number of observations in train dataset: 8273                                              
2023-06-30 13:30:46,061 - INFO: Number of observations in validation dataset: 1                                            
2023-06-30 13:30:46,163 - INFO: Using float32 for backbone                                                                 
trainable params: 131,072 || all params: 1,011,912,704 || trainable%: 0.012952895984197467                                 
2023-06-30 13:30:48,190 - INFO: Enough space available for saving model weights.                                           
2023-06-30 13:30:48,255 - INFO: Starting validation inference                                                              
2023-06-30 13:30:48,255 - INFO: validation progress:   0%|          | 0/1 [00:00<?, ?it/s]                                 
2023-06-30 13:30:58,759 - INFO: validation progress: 100%|##########| 1/1 [00:10<00:00, 10.50s/it]                         
2023-06-30 13:30:58,762 - INFO: validation progress: 100%|##########| 1/1 [00:10<00:00, 10.51s/it]
2023-06-30 13:30:58,770 - INFO: Mean validation loss: 1.90946 
2023-06-30 13:30:58,773 - INFO: Validation BLEU: 0.01722
2023-06-30 13:30:58,795 - INFO: Training Epoch: 1 / 1
2023-06-30 13:30:58,795 - INFO: train loss:   0%|          | 0/2068 [00:00<?, ?it/s]
Using pad_token, but it is not set yet.
Using cls_token, but it is not set yet.
Using sep_token, but it is not set yet.
2023-06-30 13:30:59,041 - INFO: Stop token ids: []
/Users/tmm1/.local/share/virtualenvs/h2o-llmstudio-kx1PJ3DV/lib/python3.10/site-packages/torch/utils/checkpoint.py:418: Use
rWarning: torch.utils.checkpoint: please pass in use_reentrant=True or use_reentrant=False explicitly. The default value of
 use_reentrant will be updated to be False in the future. To maintain current behavior, pass use_reentrant=True. It is reco
mmended that you use use_reentrant=False. Refer to docs for more details on the differences between the two variants.
  warnings.warn(
2023-06-30 13:32:09,685 - INFO: train loss: 1.36:   5%|4         | 103/2068 [01:10<22:32,  1.45it/s]
2023-06-30 13:32:28,336 - INFO: train loss: 1.36:   5%|4         | 103/2068 [01:29<22:32,  1.45it/s]
...
2023-06-30 13:48:54,841 - INFO: train loss: 1.17: 100%|##########| 2068/2068 [17:56<00:00,  1.92it/s]
2023-06-30 13:48:54,841 - INFO: Starting validation inference
2023-06-30 13:48:54,841 - INFO: validation progress:   0%|          | 0/1 [00:00<?, ?it/s]
2023-06-30 13:49:00,265 - INFO: validation progress: 100%|##########| 1/1 [00:05<00:00,  5.42s/it]
2023-06-30 13:49:00,267 - INFO: validation progress: 100%|##########| 1/1 [00:05<00:00,  5.43s/it]
2023-06-30 13:49:00,275 - INFO: Mean validation loss: 0.86673
2023-06-30 13:49:00,277 - INFO: Validation BLEU: 0.49945
2023-06-30 13:49:00,317 - INFO: Saving last model checkpoint: val_loss 0.86673, val_BLEU 0.49945 to examples/output_oasst1/
[1]    37069 segmentation fault  python3.10 -m pipenv run python train.py -C examples/cfg_example_oasst1.py
```