### PR TITLE
Hotfix to avoid deletion of datasets

### DIFF
--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -1819,7 +1819,7 @@ def remove_temp_files(q: Q):
     datasets_df = q.client.app_db.get_datasets_df()
     all_files = glob.glob(os.path.join(get_data_dir(q), "*"))
     for file in all_files:
-        if file not in datasets_df["path"].values:
+        if not any([path in file for path in datasets_df["path"].values]):
             if os.path.isdir(file):
                 shutil.rmtree(file)
             else:


### PR DESCRIPTION
This PR is a hotfix to an issue that was introduced in #217.

Previous to #217, the data folder was stored in the format `data/user/`, whereas now it is stored with its full path, e.g. `/home/max/PycharmProjects/h2o-llmstudio/data/user/` (i.e. `os.getcwd())}/data/`).

By this, updating from an older database, `remove_temp_files` will delete all files in `data/user/` folder. 


For a subsequent, more thorough PR, `remove_temp_files` could be rewritten to be robust against such errors, and maybe switch back to storing the data/output folder w.r.t. the root folder of llm studio.
Fixes #258