### PR TITLE
end user shall use "make llmstudio" to run without wave checking for file changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ ENV H2O_WAVE_MAX_REQUEST_SIZE=25MB
 ENV H2O_WAVE_NO_LOG=true
 ENV H2O_WAVE_PRIVATE_DIR="/download/@/workspace/output/download"
 EXPOSE 10101
-ENTRYPOINT [ "python3.10", "-m", "pipenv", "run", "wave", "run", "app" ]
+ENTRYPOINT [ "python3.10", "-m", "pipenv", "run", "wave", "run", "--no-reload", "app" ]

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ wave:
 	H2O_WAVE_PRIVATE_DIR="/download/@$(WORKDIR)/output/download" \
 	$(PIPENV) run wave run app
 
-.PHONY: wave-no-reload
-wave-no-reload:
+.PHONY: llmstudio
+llmstudio:
 	H2O_WAVE_MAX_REQUEST_SIZE=25MB \
 	H2O_WAVE_NO_LOG=true \
 	H2O_WAVE_PRIVATE_DIR="/download/@$(WORKDIR)/output/download" \

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pip install -r requirements.txt
 You can start H2O LLM Studio using the following command:
 
 ```bash
-make wave
+make llmstudio
 ```
 
 This command will start the [H2O wave](https://github.com/h2oai/wave) server and app.

--- a/app_utils/config.py
+++ b/app_utils/config.py
@@ -20,7 +20,7 @@ def get_size(x):
         return 2**31
 
 
-version = "0.0.5"
+version = "0.0.6-dev"
 
 try:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/app_utils/sections/home.py
+++ b/app_utils/sections/home.py
@@ -2,6 +2,7 @@ import psutil
 import torch
 from h2o_wave import Q, data, ui
 
+from app_utils.config import default_cfg
 from app_utils.sections.common import clean_dashboard
 from app_utils.utils import (
     get_datasets,
@@ -18,7 +19,7 @@ async def home(q: Q) -> None:
     q.client["nav/active"] = "home"
 
     experiments = get_experiments(q)
-    hdd = psutil.disk_usage("./data/")
+    hdd = psutil.disk_usage(default_cfg.llm_studio_workdir)
 
     q.page["home/disk_usage"] = ui.tall_gauge_stat_card(
         box=ui.box("content", order=2, width="20%" if len(experiments) > 0 else "30%"),

--- a/documentation/docs/get-started/set-up-llm-studio.md
+++ b/documentation/docs/get-started/set-up-llm-studio.md
@@ -65,7 +65,7 @@ There are several ways to run H2O LLM Studio depending on your requirements.
 Run the following command to start the H2O LLM Studio. 
 
 ```
-make wave
+make llmstudio
 ```
 
 This will start the H2O Wave server and the H2O LLM Studio app. Navigate to [http://localhost:10101/](http://localhost:10101/) (we recommend using Chrome) to access H2O LLM Studio and start fine-tuning your models. 

--- a/jenkins/packer/install_llm_studio_ubuntu2004.sh
+++ b/jenkins/packer/install_llm_studio_ubuntu2004.sh
@@ -37,7 +37,7 @@ After=network.target
 Type=simple
 User=ubuntu
 WorkingDirectory=/home/ubuntu/h2o-llmstudio
-ExecStart=/usr/bin/make wave
+ExecStart=/usr/bin/make llmstudio
 Restart=always
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
H2O Wave monitors the app dir for code changes by default since v0.0.9 (https://wave.h2o.ai/blog/release-0.9.0#live-reload).

We create the `h2oai_pipeline.py` file in the output directory when uploading a model to Hugging Face. When doing so a second time, this triggers the reload of wave. 

There is currently no way to disable the check for certain folders, so I decided to disable the reload check completely when not developing. For that, the end user will start the app using `make llmstudio` which starts the wave server without reloading (`--no-reload`).

closes #267 