### PR TITLE
Fix Runpod support / fix copy_config to use output dir config (#280)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY Pipfile .
 COPY Pipfile.lock .
 RUN \
     make setup && \
+    mkdir -p /home/llmstudio/mount && \
     chmod -R a+w /home/llmstudio
 COPY . .
 

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -1586,7 +1586,7 @@ def start_experiment(cfg: Any, q: Q, pre: str, gpu_list: Optional[List] = None) 
         env_vars.update(
             {"HUGGINGFACE_TOKEN": q.client["default_huggingface_api_token"]}
         )
-    cfg = copy_config(cfg)
+    cfg = copy_config(cfg, q)
     cfg.output_directory = f"{get_output_dir(q)}/{cfg.experiment_name}/"
     os.makedirs(cfg.output_directory)
     save_config_yaml(f"{cfg.output_directory}/cfg.yaml", cfg)
@@ -1864,7 +1864,7 @@ def get_single_gpu_usage(sig_figs=1, highlight=None):
     return items
 
 
-def copy_config(cfg: Any) -> Any:
+def copy_config(cfg: Any, q: Q) -> Any:
     """Makes a copy of the config
 
     Args:
@@ -1873,8 +1873,8 @@ def copy_config(cfg: Any) -> Any:
         copy of the config
     """
     # make unique yaml file using uuid
-    os.makedirs("output", exist_ok=True)
-    tmp_file = os.path.join("output/", str(uuid.uuid4()) + ".yaml")
+    os.makedirs(get_output_dir(q), exist_ok=True)
+    tmp_file = os.path.join(f"{get_output_dir(q)}/", str(uuid.uuid4()) + ".yaml")
     save_config_yaml(tmp_file, cfg)
     cfg = load_config_yaml(tmp_file)
     os.remove(tmp_file)


### PR DESCRIPTION
Fixes #280 

For example, with:

| Key | Value |
| --- | --- |
| H2O_LLM_STUDIO_WORKDIR | `/home/llmstudio/mount` |

and it will now store the temporary file in:

```diff
- /workspace/output/<UUID>.yaml
+ /home/llmstudio/mount/output/user/<UUID>.yaml
```

## Testing

- [x] Tested on Runpod
  - [x] Starts, can load home page
  - [x] Can download datasets
  - [x] Can create and start experiments

### Runpod Template

| Template Field | Value |
| --- | --- |
| Docker Image Name | `glavin001/h2o-llmstudio:latest` (use this to test if you like) |
| Volume Mount Path | `/home/llmstudio/mount` |
| Expose TCP Ports | `10101` |

Environment variables:

| Key | Value |
| --- | --- |
| H2O_LLM_STUDIO_WORKDIR | `/home/llmstudio/mount` |
| HF_DATASETS_CACHE | `/home/llmstudio/mount/huggingface-cache/datasets` |
| HUGGINGFACE_HUB_CACHE | `/home/llmstudio/mount/huggingface-cache/hub` |
| TRANSFORMERS_CACHE | `/home/llmstudio/mount/huggingface-cache/hub` |

<img width="981" alt="image" src="https://github.com/h2oai/h2o-llmstudio/assets/1885333/baa80496-f9c5-48d2-8271-4a6262de6699">
