### PR TITLE
Quantize models with AutoGPTQ (#219)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY Pipfile .
 COPY Pipfile.lock .
 RUN \
     make setup && \
+    mkdir -p /home/llmstudio/mount && \
     chmod -R a+w /home/llmstudio
 COPY . .
 

--- a/app_utils/handlers.py
+++ b/app_utils/handlers.py
@@ -24,6 +24,7 @@ from app_utils.sections.experiment import (
     experiment_display,
     experiment_download_logs,
     experiment_download_model,
+    experiment_quantize_model,
     experiment_download_predictions,
     experiment_list,
     experiment_push_to_huggingface_dialog,
@@ -302,6 +303,8 @@ async def handle(q: Q) -> None:
             await experiment_push_to_huggingface_dialog(q)
         elif q.args["experiment/display/download_model"]:
             await experiment_download_model(q)
+        elif q.args["experiment/display/quantize_model"]:
+            await experiment_quantize_model(q)
         elif q.args["experiment/display/push_to_huggingface_submit"]:
             await experiment_push_to_huggingface_dialog(q)
 

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -1587,7 +1587,7 @@ def start_experiment(cfg: Any, q: Q, pre: str, gpu_list: Optional[List] = None) 
         env_vars.update(
             {"HUGGINGFACE_TOKEN": q.client["default_huggingface_api_token"]}
         )
-    cfg = copy_config(cfg)
+    cfg = copy_config(cfg, q)
     cfg.output_directory = f"{get_output_dir(q)}/{cfg.experiment_name}/"
     os.makedirs(cfg.output_directory)
     save_config_yaml(f"{cfg.output_directory}/cfg.yaml", cfg)
@@ -1865,7 +1865,7 @@ def get_single_gpu_usage(sig_figs=1, highlight=None):
     return items
 
 
-def copy_config(cfg: Any) -> Any:
+def copy_config(cfg: Any, q: Q) -> Any:
     """Makes a copy of the config
 
     Args:
@@ -1874,8 +1874,8 @@ def copy_config(cfg: Any) -> Any:
         copy of the config
     """
     # make unique yaml file using uuid
-    os.makedirs("output", exist_ok=True)
-    tmp_file = os.path.join("output/", str(uuid.uuid4()) + ".yaml")
+    os.makedirs(get_output_dir(q), exist_ok=True)
+    tmp_file = os.path.join(f"{get_output_dir(q)}/", str(uuid.uuid4()) + ".yaml")
     save_config_yaml(tmp_file, cfg)
     cfg = load_config_yaml(tmp_file)
     os.remove(tmp_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ anyio==3.7.1 ; python_version >= '3.7'
 arrow==1.2.3 ; python_version >= '3.6'
 async-timeout==4.0.2 ; python_version >= '3.6'
 attrs==23.1.0 ; python_version >= '3.7'
+auto-gptq==0.3.0
 beautifulsoup4==4.11.1
 bitsandbytes==0.39.1
 bleach==6.0.0 ; python_version >= '3.7'


### PR DESCRIPTION
Close #219 

Reference code for successfully quantizing an LLM: https://gist.github.com/Glavin001/d66dbb93e9ea3a2cb5e0e6f1c2aa2ba1

Expects https://github.com/h2oai/h2o-llmstudio/issues/280 to be merged prior.

- [ ] Testing. Currently untested. Only had a CPU computer today. Will test with GPU later this week.
- [x] Add button to experiment's page
  - [ ] Only show button after model successfully trained (like the push, etc buttons)
- [ ] Add `autogptq` to Pipfile
- [ ] Sample from experiment's dataset
  - [x] Use experiment's configured prompt, answer, separator tokens
- [ ] Quantization configuration options per experiment
- [ ] Add AutoGPTQ inference support to Chat tab
- [ ] Push `GPTQ` model to Huggingface
