### PR TITLE
Add data sanity checks

### DIFF
--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -467,21 +467,20 @@ class CustomDataset(Dataset):
         return [system_encoding, prompt_encoding, answer_encoding]
 
     def get_parent_ids(self, idx):
-        max_loop = 1000
+        max_loop = 1_000
         parent_idxs = []
         if self.parent_ids is not None:
             parent_idx = idx
             while (
                 (parent_idx := self.df_id_to_idx.get(self.parent_ids[parent_idx], None))
-                and max_loop > 0
             ) is not None:
                 parent_idxs.append(parent_idx)
                 max_loop -= 1
-
-        if max_loop == 0:
-            raise ValueError(
-                f"Parent chain of sample with idx {idx} exceeds max loop count."
-            )
+                if max_loop == 0:
+                    raise ValueError(
+                        f"Parent chain of sample with idx {idx} exceeds max loop count. "
+                        f"Please ensure that parent chain is not circular."
+                    )
         return parent_idxs[::-1]
 
     def get_parent_encodings(self, idx):

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -336,11 +336,13 @@ class CustomDataset(Dataset):
             and "id" in df.columns
         ):
             assert (
-                df.isin(df["id"]).all()
+                df[cfg.dataset.parent_id_column].dropna().isin(df["id"]).all()
             ), "Parent id column contains ids that are not in the dataset"
             assert (
-                    df != df["id"]
+                df[cfg.dataset.parent_id_column] != df["id"]
             ).all(), "Parent id column is the same as id column for some rows"
+            assert (df[cfg.dataset.parent_id_column].fillna("") == "").sum() > 0,\
+                "Did not find any conversation start. Please ensure that some parent ids are empty."
 
     def __getitem__(self, idx: int) -> Dict:
         """Reads a single text observation."""

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -341,9 +341,10 @@ class CustomDataset(Dataset):
             assert (
                 df[cfg.dataset.parent_id_column] != df["id"]
             ).all(), "Parent id column is the same as id column for some rows"
-            assert (
-                df[cfg.dataset.parent_id_column].fillna("") == ""
-            ).sum() > 0, "Did not find any conversation start. Please ensure that some parent ids are empty."
+            assert (df[cfg.dataset.parent_id_column].fillna("") == "").sum() > 0, (
+                "Did not find any conversation start. "
+                "Please ensure that some parent ids are empty."
+            )
 
     def __getitem__(self, idx: int) -> Dict:
         """Reads a single text observation."""
@@ -415,7 +416,7 @@ class CustomDataset(Dataset):
             self.pad_tokens(
                 prompt_input_ids,
                 attention_mask=prompt_attention_mask,
-                max_length=self.cfg.tokenizer.max_length_prompt,
+                max_length=self.cfg.tokenizer.max_length,
                 pad_token_id=self.tokenizer.pad_token_id,
                 prefix="prompt_",
             )

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -40,8 +40,8 @@ class CustomDataset(Dataset):
         has_missing_values = False
         if has_all_columns:
             has_missing_values = (
-                self.df.shape[0]
-                != self.df[[cfg.dataset.answer_column]].dropna().shape[0]
+                    self.df.shape[0]
+                    != self.df[[cfg.dataset.answer_column]].dropna().shape[0]
             )
 
         if not has_all_columns or has_missing_values:
@@ -150,7 +150,7 @@ class CustomDataset(Dataset):
 
     @staticmethod
     def batch_to_device(
-        batch: Union[Dict, List, torch.Tensor], device: str
+            batch: Union[Dict, List, torch.Tensor], device: str
     ) -> Union[Dict, List, torch.Tensor, str]:
         """Function to send the batch to the device specified
 
@@ -163,7 +163,7 @@ class CustomDataset(Dataset):
         if isinstance(batch, torch.Tensor):
             return batch.to(device)
         elif isinstance(batch, (list, tuple)) and all(
-            isinstance(item, str) for item in batch
+                isinstance(item, str) for item in batch
         ):
             # Do not move list of strings to device
             return batch
@@ -260,9 +260,9 @@ class CustomDataset(Dataset):
 
     @staticmethod
     def clean_output(
-        output: Dict,
-        prompts: List[str],
-        cfg: Any,
+            output: Dict,
+            prompts: List[str],
+            cfg: Any,
     ):
         output["predicted_text"] = output["predicted_text"].tolist()
         for j in range(len(output["predicted_text"])):
@@ -301,7 +301,7 @@ class CustomDataset(Dataset):
         return output
 
     def format_output(
-        self, cfg, df: pd.DataFrame, output: Dict
+            self, cfg, df: pd.DataFrame, output: Dict
     ) -> Tuple[Dict, pd.DataFrame]:
         output = {
             key: value
@@ -331,17 +331,17 @@ class CustomDataset(Dataset):
         Quick check whether Dataframe and configurations are correctly set.
         """
         if (
-            cfg.dataset.parent_id_column is not None
-            and cfg.dataset.parent_id_column in df.columns
-            and "id" in df.columns
+                cfg.dataset.parent_id_column is not None
+                and cfg.dataset.parent_id_column in df.columns
+                and "id" in df.columns
         ):
             assert (
                 df[cfg.dataset.parent_id_column].dropna().isin(df["id"]).all()
             ), "Parent id column contains ids that are not in the dataset"
             assert (
-                df[cfg.dataset.parent_id_column] != df["id"]
+                    df[cfg.dataset.parent_id_column] != df["id"]
             ).all(), "Parent id column is the same as id column for some rows"
-            assert (df[cfg.dataset.parent_id_column].fillna("") == "").sum() > 0,\
+            assert (df[cfg.dataset.parent_id_column].fillna("") == "").sum() > 0, \
                 "Did not find any conversation start. Please ensure that some parent ids are empty."
 
     def __getitem__(self, idx: int) -> Dict:
@@ -391,10 +391,10 @@ class CustomDataset(Dataset):
                 labels[-1] = self.tokenizer.eos_token_id
 
             if self.cfg.tokenizer.max_length < len(input_ids):
-                labels = labels[-self.cfg.tokenizer.max_length :]
+                labels = labels[-self.cfg.tokenizer.max_length:]
 
             sample["labels"] = torch.full((self.cfg.tokenizer.max_length,), -100)
-            sample["labels"][-len(labels) :] = labels
+            sample["labels"][-len(labels):] = labels
 
         sample.update(
             self.pad_tokens(
@@ -475,8 +475,8 @@ class CustomDataset(Dataset):
         if self.parent_ids is not None:
             parent_idx = idx
             while (
-                parent_idx := self.df_id_to_idx.get(self.parent_ids[parent_idx], None)
-                and max_loop > 0
+                    (parent_idx := self.df_id_to_idx.get(self.parent_ids[parent_idx], None))
+                    and max_loop > 0
             ) is not None:
                 parent_idxs.append(parent_idx)
                 max_loop -= 1
@@ -497,7 +497,7 @@ class CustomDataset(Dataset):
                 parent_encoding
                 for parent_encoding in parent_encodings
                 if not np.random.random()
-                < self.cfg.augmentation.skip_parent_probability
+                       < self.cfg.augmentation.skip_parent_probability
             ]
             if np.random.random() < self.cfg.augmentation.random_parent_probability:
                 rnd_idx = np.random.randint(len(self))
@@ -516,13 +516,13 @@ class CustomDataset(Dataset):
         )
 
     def pad_tokens(
-        self,
-        input_ids,
-        attention_mask,
-        max_length,
-        pad_token_id,
-        prefix="",
-        system_ids=None,
+            self,
+            input_ids,
+            attention_mask,
+            max_length,
+            pad_token_id,
+            prefix="",
+            system_ids=None,
     ):
         sample = {}
 
@@ -532,9 +532,9 @@ class CustomDataset(Dataset):
 
         if len(input_ids) > 0:
             sample[f"{prefix}input_ids"] = torch.full((max_length,), pad_token_id)
-            sample[f"{prefix}input_ids"][-len(input_ids) :] = input_ids
+            sample[f"{prefix}input_ids"][-len(input_ids):] = input_ids
             sample[f"{prefix}attention_mask"] = torch.zeros(max_length)
-            sample[f"{prefix}attention_mask"][-len(input_ids) :] = attention_mask
+            sample[f"{prefix}attention_mask"][-len(input_ids):] = attention_mask
         else:
             # Pad everything if empty (continued pretraining)
             sample[f"{prefix}input_ids"] = torch.full((max_length,), pad_token_id)

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -478,7 +478,8 @@ class CustomDataset(Dataset):
                 max_loop -= 1
                 if max_loop == 0:
                     raise ValueError(
-                        f"Parent chain of sample with idx {idx} exceeds max loop count. "
+                        f"Parent chain of sample with idx {idx} "
+                        f"exceeds max loop count. "
                         f"Please ensure that parent chain is not circular."
                     )
         return parent_idxs[::-1]

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -336,9 +336,6 @@ class CustomDataset(Dataset):
             and "id" in df.columns
         ):
             assert (
-                df[cfg.dataset.parent_id_column].dropna().isin(df["id"]).all()
-            ), "Parent id column contains ids that are not in the dataset"
-            assert (
                 df[cfg.dataset.parent_id_column] != df["id"]
             ).all(), "Parent id column is the same as id column for some rows"
             assert (df[cfg.dataset.parent_id_column].fillna("") == "").sum() > 0, (

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -68,19 +68,6 @@ def test_sanity_check_raises_error():
     invalid_df_1 = pd.DataFrame(
         {
             "id": [1, 2, 3, 4],
-            "parent_id": [5, 6, 7, 8],
-            "other_data": ["a", "b", "c", "d"],
-        }
-    )
-    with pytest.raises(
-        AssertionError,
-        match="Parent id column contains ids that are not in the dataset",
-    ):
-        CustomDataset.sanity_check(invalid_df_1, mock_config)
-
-    invalid_df_2 = pd.DataFrame(
-        {
-            "id": [1, 2, 3, 4],
             "parent_id": [1, 2, 3, 4],
             "other_data": ["a", "b", "c", "d"],
         }
@@ -88,9 +75,9 @@ def test_sanity_check_raises_error():
     with pytest.raises(
         AssertionError, match="Parent id column is the same as id column for some rows"
     ):
-        CustomDataset.sanity_check(invalid_df_2, mock_config)
+        CustomDataset.sanity_check(invalid_df_1, mock_config)
 
-    invalid_df_3 = pd.DataFrame(
+    invalid_df_2 = pd.DataFrame(
         {
             "id": [1, 2, 3, 4],
             "parent_id": [2, 3, 4, 1],
@@ -102,7 +89,7 @@ def test_sanity_check_raises_error():
         match="Did not find any conversation start. "
         "Please ensure that some parent ids are empty.",
     ):
-        CustomDataset.sanity_check(invalid_df_3, mock_config)
+        CustomDataset.sanity_check(invalid_df_2, mock_config)
 
 
 @pytest.fixture

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -153,6 +153,33 @@ def test_get_parent_ids(mock_auto_tokenizer):
     assert dataset.get_parent_ids(2) == [0, 1]
 
 
+def test_loop_fails(mock_auto_tokenizer):
+    df = pd.DataFrame(
+        {
+            "prompt": ["prompt 1", "prompt 2", "prompt 3"],
+            "answer": ["answer 1", "answer 2", "answer 3"],
+            "parent_id": [0, 1, 2],
+            "id": [1, 2, 0],
+        }
+    )
+
+    cfg = mock.MagicMock()
+    cfg.dataset.prompt_column = "prompt"
+    cfg.dataset.answer_column = "answer"
+    cfg.dataset.parent_id_column = "parent_id"
+    cfg.dataset.text_system_start = "System:"
+    cfg.dataset.text_prompt_start = "Prompt:"
+    cfg.dataset.text_answer_separator = "Answer:"
+
+    dataset = CustomDataset(df, cfg)
+    with pytest.raises(
+        ValueError,
+        match="Parent chain of sample with idx 2 exceeds max loop count. "
+        "Please ensure that parent chain is not circular.",
+    ):
+        dataset.get_parent_ids(2)
+
+
 def test_getitem():
     df = pd.DataFrame(
         {

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -6,6 +6,11 @@ import pandas as pd
 import pytest
 import torch
 
+from llm_studio.python_configs.text_causal_language_modeling_config import (
+    ConfigNLPCausalLMDataset,
+    ConfigNLPCausalLMTokenizer,
+    ConfigProblemBase,
+)
 from llm_studio.src.datasets.text_causal_language_modeling_ds import CustomDataset
 
 
@@ -41,35 +46,62 @@ def test_clean_output():
 
 def test_sanity_check_raises_error():
     mock_config = MagicMock()
-    mock_config.dataset.parent_id_column = 'parent_id'
+    mock_config.dataset.parent_id_column = "parent_id"
 
-    df_1 = pd.DataFrame({"id": [1, 2, 3, 4],
-                         "parent_id": [2, None, 4, 1],
-                         "other_data": ['a', 'b', 'c', 'd']})
+    df_1 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "parent_id": [2, None, 4, 1],
+            "other_data": ["a", "b", "c", "d"],
+        }
+    )
     CustomDataset.sanity_check(df_1, mock_config)
 
-    df_2 = pd.DataFrame({"id": [1, 2, 3, 4],
-                         "parent_id": [None, None, None, None],
-                         "other_data": ['a', 'b', 'c', 'd']})
+    df_2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "parent_id": [None, None, None, None],
+            "other_data": ["a", "b", "c", "d"],
+        }
+    )
     CustomDataset.sanity_check(df_2, mock_config)
 
-    invalid_df_1 = pd.DataFrame({"id": [1, 2, 3, 4],
-                                 "parent_id": [5, 6, 7, 8],
-                                 "other_data": ['a', 'b', 'c', 'd']})
-    with pytest.raises(AssertionError, match="Parent id column contains ids that are not in the dataset"):
+    invalid_df_1 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "parent_id": [5, 6, 7, 8],
+            "other_data": ["a", "b", "c", "d"],
+        }
+    )
+    with pytest.raises(
+        AssertionError,
+        match="Parent id column contains ids that are not in the dataset",
+    ):
         CustomDataset.sanity_check(invalid_df_1, mock_config)
 
-    invalid_df_2 = pd.DataFrame({"id": [1, 2, 3, 4],
-                                 "parent_id": [1, 2, 3, 4],
-                                 "other_data": ['a', 'b', 'c', 'd']})
-    with pytest.raises(AssertionError, match="Parent id column is the same as id column for some rows"):
+    invalid_df_2 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "parent_id": [1, 2, 3, 4],
+            "other_data": ["a", "b", "c", "d"],
+        }
+    )
+    with pytest.raises(
+        AssertionError, match="Parent id column is the same as id column for some rows"
+    ):
         CustomDataset.sanity_check(invalid_df_2, mock_config)
 
-    invalid_df_3 = pd.DataFrame({"id": [1, 2, 3, 4],
-                                 "parent_id": [2, 3, 4, 1],
-                                 "other_data": ['a', 'b', 'c', 'd']})
-    with pytest.raises(AssertionError,
-                       match="Did not find any conversation start. Please ensure that some parent ids are empty."):
+    invalid_df_3 = pd.DataFrame(
+        {
+            "id": [1, 2, 3, 4],
+            "parent_id": [2, 3, 4, 1],
+            "other_data": ["a", "b", "c", "d"],
+        }
+    )
+    with pytest.raises(
+        AssertionError,
+        match="Did not find any conversation start. Please ensure that some parent ids are empty.",
+    ):
         CustomDataset.sanity_check(invalid_df_3, mock_config)
 
 
@@ -77,20 +109,24 @@ def test_sanity_check_raises_error():
 def mock_auto_tokenizer():
     # from
     # https://github.com/deepset-ai/haystack/blob/b5aef24a7ebac55cb4ba492baf81a85598700b94/test/conftest.py#L908
-    with patch("transformers.AutoTokenizer.from_pretrained", autospec=True) as mock_from_pretrained:
+    with patch(
+        "transformers.AutoTokenizer.from_pretrained", autospec=True
+    ) as mock_from_pretrained:
         yield mock_from_pretrained
 
 
 def test_init(mock_auto_tokenizer):
-    df = pd.DataFrame({
-        'col_A': [1, 2, 3],
-        'col_B': [4, 5, 6],
-    })
+    df = pd.DataFrame(
+        {
+            "col_A": [1, 2, 3],
+            "col_B": [4, 5, 6],
+        }
+    )
     cfg = mock.MagicMock()
-    cfg.dataset.prompt_column = 'col_A'
-    cfg.dataset.answer_column = 'col_B'
-    cfg.dataset.parent_id_column = 'None'
-    cfg.dataset.system_column = 'None'
+    cfg.dataset.prompt_column = "col_A"
+    cfg.dataset.answer_column = "col_B"
+    cfg.dataset.parent_id_column = "None"
+    cfg.dataset.system_column = "None"
 
     cfg.dataset.text_system_start = ""
     cfg.dataset.text_prompt_start = ""
@@ -99,22 +135,26 @@ def test_init(mock_auto_tokenizer):
     dataset = CustomDataset(df, cfg)
 
     assert dataset.df.equals(df)
-    assert dataset.mode == 'train'
+    assert dataset.mode == "train"
     assert all(dataset.indices == np.array([0, 1, 2]))
     assert all(dataset.raw_prompts == ["1", "2", "3"])
     assert dataset.answers == ["4", "5", "6"]
 
 
 def test_get_parent_ids(mock_auto_tokenizer):
-    df = pd.DataFrame({'prompt': ['prompt 1', 'prompt 2', 'prompt 3'],
-                       'answer': ['answer 1', 'answer 2', 'answer 3'],
-                       'parent_id': [None, 0, 1],
-                       'id': [0, 1, 2]})
+    df = pd.DataFrame(
+        {
+            "prompt": ["prompt 1", "prompt 2", "prompt 3"],
+            "answer": ["answer 1", "answer 2", "answer 3"],
+            "parent_id": [None, 0, 1],
+            "id": [0, 1, 2],
+        }
+    )
 
     cfg = mock.MagicMock()
-    cfg.dataset.prompt_column = 'prompt'
-    cfg.dataset.answer_column = 'answer'
-    cfg.dataset.parent_id_column = 'parent_id'
+    cfg.dataset.prompt_column = "prompt"
+    cfg.dataset.answer_column = "answer"
+    cfg.dataset.parent_id_column = "parent_id"
     cfg.dataset.text_system_start = "System:"
     cfg.dataset.text_prompt_start = "Prompt:"
     cfg.dataset.text_answer_separator = "Answer:"
@@ -127,41 +167,62 @@ def test_get_parent_ids(mock_auto_tokenizer):
 
 
 def test_getitem(mock_auto_tokenizer):
-    df = pd.DataFrame({'prompt': ['prompt 1', 'prompt 2', 'prompt 3'],
-                       'answer': ['answer 1', 'answer 2', 'answer 3'],
-                       'parent_id': [None, 0, 1],
-                       'system': ['system 1', 'system 2', 'system 3'],
-                       'id': [0, 1, 2]})
+    df = pd.DataFrame(
+        {
+            "prompt": ["prompt 1", "prompt 2", "prompt 3"],
+            "answer": ["answer 1", "answer 2", "answer 3"],
+            "parent_id": [None, 0, 1],
+            "system": ["system 1", "system 2", "system 3"],
+            "id": [0, 1, 2],
+        }
+    )
 
-    cfg = mock.MagicMock()
-    cfg.dataset.prompt_column = 'prompt'
-    cfg.dataset.answer_column = 'answer'
-    cfg.dataset.parent_id_column = 'parent_id'
-    cfg.dataset.system_column = 'system'
-    cfg.dataset.text_system_start = "System:"
-    cfg.dataset.text_prompt_start = "Prompt:"
-    cfg.dataset.text_answer_separator = "Answer:"
-
-    cfg.tokenizer.max_length = 256
-    cfg.tokenizer.max_length_answer = 256
-    cfg.tokenizer.max_length_prompt = 256
-    cfg.dataset.add_eos_token_to_answer = True
+    cfg = ConfigProblemBase(
+        dataset=ConfigNLPCausalLMDataset(
+            prompt_column=("prompt",),
+            answer_column="answer",
+            parent_id_column="parent_id",
+            system_column="system",
+            text_system_start="System:",
+            text_prompt_start="Prompt:",
+            text_answer_separator="Answer:",
+            add_eos_token_to_answer=True,
+        )
+    )
 
     dataset = CustomDataset(df, cfg)
 
     def tokenize(text, **kwargs):
-        words = text.split()
-        return {'input_ids': torch.Tensor([1, 2, 3, 4, 5, 6, 7, 8, 9, 10][:len(words)])[None],
-                'attention_mask': torch.ones(len(words))[None]
-                }
+        offset = 0
+        if "1" in text:
+            offset = 1
+        elif "2" in text:
+            offset = 2
+        elif "3" in text:
+            offset = 3
+
+        if "prompt" in text:
+            sample = {
+                "input_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10][offset:],
+                "attention_mask": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1][offset:],
+            }
+        elif "answer" in text:
+            sample = {
+                "input_ids": [11, 12, 13, 14, 15, 16, 17, 18, 19, 20][offset:],
+                "attention_mask": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1][offset:],
+            }
+        elif "system" in text:
+            sample = {
+                "input_ids": [21, 22, 23, 24, 25, 26, 27, 28, 29, 30][offset:],
+                "attention_mask": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1][offset:],
+            }
+        else:
+            sample = {"input_ids": [31], "attention_mask": [1]}
+        return {k: torch.tensor(v)[None] for k, v in sample.items()}
 
     dataset.tokenizer = mock.MagicMock(side_effect=tokenize)
     dataset.tokenizer.eos_token_id = 999
-
-    # dataset._get_sample_encoding = mock.MagicMock(return_value=[torch.Tensor(), torch.Tensor(), torch.Tensor()])
-    # dataset.get_parent_encodings = mock.MagicMock(return_value=[])
-    # dataset.get_reward_model_parent_prompt_text = mock.MagicMock(return_value="")
-    # dataset.pad_tokens = mock.MagicMock(return_value={'key': 'value'})
+    dataset.tokenizer.pad_token_id = 1000
 
     result = dataset[0]
     assert isinstance(result, dict)

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -1,6 +1,10 @@
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pandas as pd
+import pytest
+import torch
 
 from llm_studio.src.datasets.text_causal_language_modeling_ds import CustomDataset
 
@@ -33,3 +37,108 @@ def test_clean_output():
         "",
         "This is a test",
     ]
+
+
+def test_sanity_check():
+    data = {"id": [1, 2, 3, 4],
+            "parent_id": [2, 3, 4, 1],
+            "other_data": ['a', 'b', 'c', 'd']}
+
+    df = pd.DataFrame(data)
+
+    mock_config = MagicMock()
+    mock_config.dataset.parent_id_column = 'parent_id'
+
+    # When / Then
+    CustomDataset.sanity_check(df, mock_config)
+
+    # Check with invalid dataframe
+    invalid_data = {"id": [1, 2, 3, 4],
+                    "parent_id": [5, 6, 7, 8],
+                    "other_data": ['a', 'b', 'c', 'd']}
+
+    invalid_df = pd.DataFrame(invalid_data)
+
+    with pytest.raises(AssertionError, match="Parent id column contains ids that are not in the dataset"):
+        CustomDataset.sanity_check(invalid_df, mock_config)
+
+    # Check with invalid dataframe
+    invalid_data_2 = {"id": [1, 2, 3, 4],
+                      "parent_id": [1, 2, 3, 4],
+                      "other_data": ['a', 'b', 'c', 'd']}
+
+    invalid_df_2 = pd.DataFrame(invalid_data_2)
+    with pytest.raises(AssertionError, match="Parent id column is the same as id column for some rows"):
+        CustomDataset.sanity_check(invalid_df_2, mock_config)
+
+
+@pytest.fixture
+def mock_auto_tokenizer():
+    # from
+    # https://github.com/deepset-ai/haystack/blob/b5aef24a7ebac55cb4ba492baf81a85598700b94/test/conftest.py#L908
+    with patch("transformers.AutoTokenizer.from_pretrained", autospec=True) as mock_from_pretrained:
+        yield mock_from_pretrained
+
+
+def test_init(mock_auto_tokenizer):
+    df = pd.DataFrame({
+        'col_A': [1, 2, 3],
+        'col_B': [4, 5, 6],
+    })
+    cfg = mock.MagicMock()
+    cfg.dataset.prompt_column = 'col_A'
+    cfg.dataset.answer_column = 'col_B'
+    cfg.dataset.parent_id_column = 'None'
+    cfg.dataset.system_column = 'None'
+
+    cfg.dataset.text_system_start = ""
+    cfg.dataset.text_prompt_start = ""
+    cfg.dataset.text_answer_separator = ""
+
+    dataset = CustomDataset(df, cfg)
+
+    assert dataset.df.equals(df)
+    assert dataset.mode == 'train'
+    assert all(dataset.indices == np.array([0, 1, 2]))
+
+
+def test_len(mock_auto_tokenizer):
+    df = pd.DataFrame({'col_A': [1, 2, 3]})
+    cfg = mock.MagicMock()
+    cfg.dataset.answer_column = 'col_A'
+    cfg.dataset.parent_id_column = 'None'
+    cfg.dataset.system_column = 'None'
+    cfg.dataset.text_system_start = ""
+    cfg.dataset.text_prompt_start = ""
+    cfg.dataset.text_answer_separator = ""
+    dataset = CustomDataset(df, cfg)
+    assert len(dataset) == 3
+
+
+def test_getitem(mock_auto_tokenizer):
+    df = pd.DataFrame({'col_A': ['text 1', 'text 2', 'text 3'], 'col_B': ['text 4', 'text 5', 'text 6']})
+    cfg = mock.MagicMock()
+    cfg.dataset.answer_column = 'col_A'
+    cfg.dataset.parent_id_column = 'None'
+    cfg.dataset.system_column = 'None'
+    cfg.dataset.text_system_start = ""
+    cfg.dataset.text_prompt_start = ""
+    cfg.dataset.text_answer_separator = ""
+
+    dataset = CustomDataset(df, cfg)
+
+    with mock.patch("torch.Tensor") as mock_tensor:
+        mock_tensor.configure_mock(**{"__eq__.return_value": True})
+
+        dataset._get_sample_encoding = mock.MagicMock(return_value=[torch.Tensor(), torch.Tensor(), torch.Tensor()])
+        dataset.get_parent_encodings = mock.MagicMock(return_value=[])
+        dataset.get_reward_model_parent_prompt_text = mock.MagicMock(return_value="")
+        dataset.pad_tokens = mock.MagicMock(return_value={'key': 'value'})
+
+        result = dataset.__getitem__(0)
+
+        # Check if __getitem__ calls the appropriate methods and returns the correct result
+        dataset._get_sample_encoding.assert_called_once_with(0)
+        dataset.get_parent_encodings.assert_called_once_with(0)
+        dataset.pad_tokens.assert_called()
+        assert isinstance(result, dict)


### PR DESCRIPTION
This PR adds sanity checks to the data to catch an error that occurs when `parent id == id` is set. To further avoid an infinite while loop originating from bad data input, the loop is stopped after 1000 iterations.


During refactoring I also changed the following two items. Happy to discuss :)

- `prompt_input_ids` is now truncated/padded to `cfg.tokenizer.max_length` instead of `cfg.tokenizer.max_length_prompt`.
I think the change is useful, as `max_length_prompt` denotes the length of an individual prompt, whereas `prompt_input_ids` may consist of a chained Q&A pairs where only the last answer has been removed. 

- ~~`cfg.augmentation.random_parent_probability` (add a random parent) is only used when the dataset has a parent id column.~~

Fixes https://github.com/h2oai/h2o-llmstudio/issues/283
Fixes #257