### PR TITLE
Removal of llama force slow

### DIFF
--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -31,7 +31,6 @@ def get_texts(df, cfg, separator=None):
 
 
 def get_tokenizer(cfg: Any):
-
     kwargs = dict(
         revision=cfg.environment.huggingface_branch,
         add_prefix_space=cfg.tokenizer.add_prefix_space,

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -31,9 +31,6 @@ def get_texts(df, cfg, separator=None):
 
 
 def get_tokenizer(cfg: Any):
-    if "llama" in cfg.llm_backbone:
-        logger.info("Llama backbone detected, forcing slow tokenizer.")
-        cfg.tokenizer.use_fast = False
 
     kwargs = dict(
         revision=cfg.environment.huggingface_branch,


### PR DESCRIPTION
Decided to remove the manual llama slow tokenizer fix.

User should make this choice. LLama 2 for example works with fast tokenizer also.