### PR TITLE
LLama2 config fix

### DIFF
--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -496,6 +496,7 @@ def update_backbone_config(config: Any, cfg: Any):
     if "mpt-" in cfg.llm_backbone:
         config.init_device = cfg.environment._device
 
+    # See: https://github.com/huggingface/transformers/pull/24906
     if hasattr(config, "pretraining_tp"):
         logger.info("Setting pretraining_tp of model config to 1.")
         config.pretraining_tp = 1

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -497,7 +497,7 @@ def update_backbone_config(config: Any, cfg: Any):
         config.init_device = cfg.environment._device
 
     # See: https://github.com/huggingface/transformers/pull/24906
-    if hasattr(config, "pretraining_tp"):
+    if hasattr(config, "pretraining_tp") and cfg.training.lora:
         logger.info("Setting pretraining_tp of model config to 1.")
         config.pretraining_tp = 1
 

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -496,6 +496,10 @@ def update_backbone_config(config: Any, cfg: Any):
     if "mpt-" in cfg.llm_backbone:
         config.init_device = cfg.environment._device
 
+    if hasattr(config, "pretraining_tp"):
+        logger.info("Setting pretraining_tp of model config to 1.")
+        config.pretraining_tp = 1
+
     return config
 
 


### PR DESCRIPTION
This fix is needed to make LLama training currently work with peft and is also a reasonable change without lora training.

> Setting config.pretraining_tp to a value different than 1 will activate the more accurate but slower computation of the linear layers, which should better match the original logits.

See discussions:
https://github.com/huggingface/peft/pull/728
https://github.com/huggingface/transformers/pull/24906