### PR TITLE
Use unk token for pad if available

### DIFF
--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -56,7 +56,10 @@ def get_tokenizer(cfg: Any):
         tokenizer.eos_token = "</s>"
 
     if tokenizer.pad_token is None:
-        tokenizer.pad_token = tokenizer.eos_token
+        if tokenizer.unk_token is not None:
+            tokenizer.pad_token = tokenizer.unk_token
+        else:
+            tokenizer.pad_token = tokenizer.eos_token
     if tokenizer.bos_token is None:
         tokenizer.bos_token = tokenizer.eos_token
     if tokenizer.cls_token is None:


### PR DESCRIPTION
Using the eos token as a pad token can have side-effects for example in llama2 as we also use the eos token with attention and llama2 code has for example a routine to pass the index to ignore it for embedding calculations.

Using unk sounds fair to me, wdyt? This one exists for llama2 with index 0 and is also marked here:
https://huggingface.co/meta-llama/Llama-2-13b-hf/blob/main/config.json#L18

Should also go hand-in-hand with potential mask augmentation where we would use it.

Also see: https://huggingface.co/docs/transformers/main/model_doc/llama2

> The original model uses pad_id = -1 which means that there is no padding token. We can’t have the same logic, make sure to add a padding token using tokenizer.add_special_tokens({"pad_token":"<pad>"}) and resize the token embedding accordingly. You should also set the model.config.pad_token_id. The embed_tokens layer of the model is initialized with self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.config.padding_idx), which makes sure that encoding the padding token will output zeros, so passing it when initializing is recommended.