### PR TITLE
Add required URLs to LLM Studio installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please note that due to current rapid development we cannot guarantee full backw
 
 H2O LLM Studio requires a machine with Ubuntu 16.04+ and at least one recent Nvidia GPU with Nvidia drivers version >= 470.57.02. For larger models, we recommend at least 24GB of GPU memory.
 
-For additional information about installation prerequisites, see the [Set up H2O LLM Studio](https://docs.h2o.ai/h2o-llmstudio/get-started/set-up-llm-studio#prerequisites) guide in the documentation. 
+For more information about installation prerequisites, see the [Set up H2O LLM Studio](https://docs.h2o.ai/h2o-llmstudio/get-started/set-up-llm-studio#prerequisites) guide in the documentation. 
 
 ### Recommended Install
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Please note that due to current rapid development we cannot guarantee full backw
 
 H2O LLM Studio requires a machine with Ubuntu 16.04+ and at least one recent Nvidia GPU with Nvidia drivers version >= 470.57.02. For larger models, we recommend at least 24GB of GPU memory.
 
+For additional information about installation prerequisites, see the [Set up H2O LLM Studio](https://docs.h2o.ai/h2o-llmstudio/get-started/set-up-llm-studio#prerequisites) guide in the documentation. 
+
 ### Recommended Install
 
 The recommended way to install H2O LLM Studio is using pipenv with Python 3.10. To install Python 3.10 on Ubuntu 16.04+, execute the following commands:

--- a/documentation/docs/get-started/set-up-llm-studio.md
+++ b/documentation/docs/get-started/set-up-llm-studio.md
@@ -18,7 +18,7 @@ H2O LLM Studio requires the following minimum requirements:
 
 :::info Notes
 - Atleast 24GB of GPU memory is recommended for larger models.
-- The required URLs will be accessible by default when you start a GCP instance, however, if you have network rules or custom firewalls in place, it is recommended to confirm that the URLs are accessible before running `make setup`.
+- The required URLs are accessible by default when you start a GCP instance, however, if you have network rules or custom firewalls in place, it is recommended to confirm that the URLs are accessible before running `make setup`.
 :::
 
 

--- a/documentation/docs/get-started/set-up-llm-studio.md
+++ b/documentation/docs/get-started/set-up-llm-studio.md
@@ -9,10 +9,18 @@ H2O LLM Studio requires the following minimum requirements:
 
 - A machine with Ubuntu 16.04+ with atleast one recent Nvidia GPU 
 - Nvidia drivers v470.57.02 or a later version
+- Access to the following URLs:
+  - developer.download.nvidia.com
+  - pypi.org
+  - huggingface.co
+  - download.pytorch.org
+  - cdn-lfs.huggingface.co 
 
-:::info
-Atleast 24GB of GPU memory is recommended for larger models.
+:::info Notes
+- Atleast 24GB of GPU memory is recommended for larger models.
+- The required URLs will be reachable by default if you just start a GCP instance, however, if you have network rules or custom firewalls in place, it is recommended to ensure that the URLs are accessible before running `make setup`.
 :::
+
 
 ## Installation
 

--- a/documentation/docs/get-started/set-up-llm-studio.md
+++ b/documentation/docs/get-started/set-up-llm-studio.md
@@ -18,7 +18,7 @@ H2O LLM Studio requires the following minimum requirements:
 
 :::info Notes
 - Atleast 24GB of GPU memory is recommended for larger models.
-- The required URLs will be reachable by default if you just start a GCP instance, however, if you have network rules or custom firewalls in place, it is recommended to ensure that the URLs are accessible before running `make setup`.
+- The required URLs will be accessible by default when you start a GCP instance, however, if you have network rules or custom firewalls in place, it is recommended to confirm that the URLs are accessible before running `make setup`.
 :::
 
 


### PR DESCRIPTION
This PR adds the following URLs that must be accessible in order to set up LLM Studio, to the installation guide:
  - developer.download.nvidia.com
  - pypi.org
  - huggingface.co
  - download.pytorch.org
  - cdn-lfs.huggingface.co 


 