### PR TITLE
New Experiment Summary page

### DIFF
--- a/app_utils/cards.py
+++ b/app_utils/cards.py
@@ -196,10 +196,39 @@ def card_zones(mode: Optional[str] = "full") -> List[ui.Zone]:
                 ],
             ),
         ]
-
+    elif mode in ["experiment/display/summary"]:
+        zones = [
+            header_zone(),
+            ui.zone(
+                "body",
+                size="1",
+                direction=ui.ZoneDirection.ROW,
+                zones=[
+                    navigation_zone(),
+                    ui.zone(
+                        "content_all",
+                        direction=ui.ZoneDirection.COLUMN,
+                        size="87.5%",
+                        zones=[
+                            ui.zone("nav2", size="60px"),
+                            ui.zone(
+                                "first",
+                                size="calc((100vh - 220px)/3)",
+                                direction=ui.ZoneDirection.ROW,
+                            ),
+                            ui.zone(
+                                "second",
+                                size="calc(2*(100vh - 220px)/3)",
+                                direction=ui.ZoneDirection.ROW,
+                            ),
+                            ui.zone("footer", size="80px"),
+                        ],
+                    ),
+                ],
+            ),
+        ]
     elif mode in [
         "experiment/compare/config",
-        "experiment/display/summary",
         "experiment/display/train_data_insights",
         "experiment/display/validation_prediction_insights",
         "experiment/display/config",

--- a/app_utils/cards.py
+++ b/app_utils/cards.py
@@ -213,12 +213,17 @@ def card_zones(mode: Optional[str] = "full") -> List[ui.Zone]:
                             ui.zone("nav2", size="60px"),
                             ui.zone(
                                 "first",
-                                size="calc((100vh - 220px)/3)",
+                                size="calc(2.5*(100vh - 220px)/10)",
                                 direction=ui.ZoneDirection.ROW,
                             ),
                             ui.zone(
                                 "second",
-                                size="calc(2*(100vh - 220px)/3)",
+                                size="calc(2.5*(100vh - 220px)/10)",
+                                direction=ui.ZoneDirection.ROW,
+                            ),
+                            ui.zone(
+                                "third",
+                                size="calc(5*(100vh - 220px)/10)",
                                 direction=ui.ZoneDirection.ROW,
                             ),
                             ui.zone("footer", size="80px"),

--- a/app_utils/cards.py
+++ b/app_utils/cards.py
@@ -213,17 +213,17 @@ def card_zones(mode: Optional[str] = "full") -> List[ui.Zone]:
                             ui.zone("nav2", size="60px"),
                             ui.zone(
                                 "first",
-                                size="calc(2.5*(100vh - 220px)/10)",
+                                size="calc(0.25*(100vh - 220px))",
                                 direction=ui.ZoneDirection.ROW,
                             ),
                             ui.zone(
                                 "second",
-                                size="calc(2.5*(100vh - 220px)/10)",
+                                size="calc(0.25*(100vh - 220px))",
                                 direction=ui.ZoneDirection.ROW,
                             ),
                             ui.zone(
                                 "third",
-                                size="calc(5*(100vh - 220px)/10)",
+                                size="calc(0.5*(100vh - 220px))",
                                 direction=ui.ZoneDirection.ROW,
                             ),
                             ui.zone("footer", size="80px"),

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -1062,18 +1062,6 @@ async def summary_tab(experiment_id, q):
                 justify="between",
                 inset=True,
             ),
-            ui.stats(
-                [
-                    ui.stat(
-                        value="-"
-                        if cfg._parent_experiment == ""
-                        else cfg._parent_experiment,
-                        label="Parent Experiment Name",
-                    ),
-                ],
-                justify="between",
-                inset=True,
-            ),
         ],
     )
     q.client.delete_cards.add(card_name)
@@ -1191,6 +1179,52 @@ async def summary_tab(experiment_id, q):
                 inset=True,
             ),
         ],
+    )
+    q.client.delete_cards.add(card_name)
+
+    # todo: shall we really have this card? If so, we can read it from model card markdown file?
+    # code card
+    device_map = '{"": "cuda:0"}'
+    content = f"""
+To use the model with the transformers library on a machine with GPUs, first make sure you have the transformers, accelerate, torch and einops libraries installed.
+```python\n
+pip install transformers==4.29.2
+pip install accelerate==0.19.0
+pip install torch==2.0.0
+pip install einops==0.6.1
+```
+
+```python\n
+import torch
+from transformers import pipeline
+
+generate_text = pipeline(
+    model="h2oai/h2ogpt-gm-oasst1-en-1024-open-llama-7b-preview-400bt",
+    torch_dtype=torch.{cfg.architecture.backbone_dtype},
+    trust_remote_code=True,
+    use_fast=False,
+    device_map={device_map},
+)
+
+res = generate_text(
+    "Why is drinking water so healthy?",
+    min_new_tokens=2,
+    max_new_tokens=512,
+    do_sample=False,
+    num_beams=1,
+    temperature=float(0.3),
+    repetition_penalty=float(1.2),
+    renormalize_logits=True
+)
+print(res[0]["generated_text"])
+
+```
+"""
+    card_name = "experiment/display/summary/code"
+    q.page[card_name] = ui.markdown_card(
+        box=ui.box(zone="third"),
+        title="",
+        content=content,
     )
     q.client.delete_cards.add(card_name)
 

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -1844,6 +1844,7 @@ def get_experiment_summary_code_card(cfg) -> str:
     # Configs
     text = text.replace("{{min_new_tokens}}", str(cfg.prediction.min_length_inference))
     text = text.replace("{{max_new_tokens}}", str(cfg.prediction.max_length_inference))
+    text = text.replace("{{use_fast}}", str(cfg.tokenizer.use_fast))
     text = text.replace("{{do_sample}}", str(cfg.prediction.do_sample))
     text = text.replace("{{num_beams}}", str(cfg.prediction.num_beams))
     text = text.replace("{{temperature}}", str(cfg.prediction.temperature))

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -40,9 +40,6 @@ from app_utils.utils import (
     start_experiment,
 )
 from app_utils.wave_utils import busy_dialog, ui_table_from_df, wave_theme
-from llm_studio.python_configs.text_causal_language_modeling_config import (
-    ConfigProblemBase,
-)
 from llm_studio.src.tooltips import tooltips
 from llm_studio.src.utils.config_utils import (
     load_config_py,
@@ -1829,7 +1826,7 @@ def get_model_card(cfg, model, repo_id) -> huggingface_hub.ModelCard:
     return card
 
 
-def get_experiment_summary_code_card(cfg: ConfigProblemBase) -> str:
+def get_experiment_summary_code_card(cfg) -> str:
     with open("experiment_summary_code_template.md", "r") as f:
         text = f.read()
 

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -41,6 +41,9 @@ from app_utils.utils import (
     start_experiment,
 )
 from app_utils.wave_utils import busy_dialog, ui_table_from_df, wave_theme
+from llm_studio.python_configs.text_causal_language_modeling_config import (
+    ConfigProblemBase,
+)
 from llm_studio.src.tooltips import tooltips
 from llm_studio.src.utils.config_utils import (
     get_parent_element,
@@ -1184,46 +1187,32 @@ async def summary_tab(experiment_id, q):
 
     # todo: shall we really have this card? If so, we can read it from model card markdown file?
     # code card
-    device_map = '{"": "cuda:0"}'
-    content = f"""
-To use the model with the transformers library on a machine with GPUs, first make sure you have the transformers, accelerate, torch and einops libraries installed.
-```python\n
-pip install transformers==4.29.2
-pip install accelerate==0.19.0
-pip install torch==2.0.0
-pip install einops==0.6.1
-```
-
-```python\n
-import torch
-from transformers import pipeline
-
-generate_text = pipeline(
-    model="h2oai/h2ogpt-gm-oasst1-en-1024-open-llama-7b-preview-400bt",
-    torch_dtype=torch.{cfg.architecture.backbone_dtype},
-    trust_remote_code=True,
-    use_fast=False,
-    device_map={device_map},
-)
-
-res = generate_text(
-    "Why is drinking water so healthy?",
-    min_new_tokens=2,
-    max_new_tokens=512,
-    do_sample=False,
-    num_beams=1,
-    temperature=float(0.3),
-    repetition_penalty=float(1.2),
-    renormalize_logits=True
-)
-print(res[0]["generated_text"])
-
-```
-"""
+    content = get_experiment_summary_code_card(cfg=cfg)
     card_name = "experiment/display/summary/code"
     q.page[card_name] = ui.markdown_card(
         box=ui.box(zone="third"),
-        title="",
+        title="
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        ",
         content=content,
     )
     q.client.delete_cards.add(card_name)
@@ -1857,3 +1846,26 @@ def get_model_card(cfg, model, repo_id) -> huggingface_hub.ModelCard:
         else "",
     )
     return card
+
+
+def get_experiment_summary_code_card(cfg: ConfigProblemBase) -> str:
+    with open("experiment_summary_code_template.md", "r") as f:
+        text = f.read()
+
+    # Versions
+    text = text.replace("{{transformers_version}}", transformers.__version__)
+    text = text.replace("{{einops_version}}", einops.__version__)
+    text = text.replace("{{accelerate_version}}", accelerate.__version__)
+    text = text.replace("{{torch_version}}", torch.__version__)
+
+    # Configs
+    text = text.replace("{{min_new_tokens}}", str(cfg.prediction.min_length_inference))
+    text = text.replace("{{max_new_tokens}}", str(cfg.prediction.max_length_inference))
+    text = text.replace("{{do_sample}}", str(cfg.prediction.do_sample))
+    text = text.replace("{{num_beams}}", str(cfg.prediction.num_beams))
+    text = text.replace("{{temperature}}", str(cfg.prediction.temperature))
+    text = text.replace(
+        "{{repetition_penalty}}", str(cfg.prediction.repetition_penalty)
+    )
+
+    return text

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -1191,28 +1191,7 @@ async def summary_tab(experiment_id, q):
     card_name = "experiment/display/summary/code"
     q.page[card_name] = ui.markdown_card(
         box=ui.box(zone="third"),
-        title="
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        ",
+        title="",
         content=content,
     )
     q.client.delete_cards.add(card_name)

--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -34,7 +34,6 @@ from app_utils.utils import (
     get_problem_types,
     get_ui_elements,
     get_unique_name,
-    make_label,
     parse_ui_elements,
     remove_model_type,
     set_env,
@@ -46,7 +45,6 @@ from llm_studio.python_configs.text_causal_language_modeling_config import (
 )
 from llm_studio.src.tooltips import tooltips
 from llm_studio.src.utils.config_utils import (
-    get_parent_element,
     load_config_py,
     load_config_yaml,
     save_config_yaml,
@@ -1033,7 +1031,6 @@ async def insights_tab(charts, q):
 async def summary_tab(experiment_id, q):
     experiment_df = get_experiments(q)
     input_dict = experiment_df[experiment_df.id == experiment_id].iloc[0].to_dict()
-    items = []
     cfg = load_config_yaml(
         os.path.join(q.client["experiment/display/experiment_path"], "cfg.yaml")
     )

--- a/experiment_summary_code_template.md
+++ b/experiment_summary_code_template.md
@@ -2,17 +2,20 @@
 
 To use the model with the <b>`transformers`</b> library on a machine with GPUs:
 - First, push the model to a huggingface repo by clicking the <b>Push checkpoint to huggingface</b> button below
-- Make sure you have the <b>`transformers`</b>, <b>`accelerate`</b> and <b>`torch`</b> libraries installed in the machine's environment
+- Make sure you have the <b>`transformers`</b> library installed in the machine's environment
 
 ```bash
 pip install transformers=={{transformers_version}}
-pip install einops=={{einops_version}}
-pip install accelerate=={{accelerate_version}}
-pip install torch=={{torch_version}}
 ```
 - Pass model path from the huggingface repo to the following pipeline
+- Also make sure you are providing your huggingface token to the pipeline if the model is lying in a private repo.
+   - Either leave <b>token=True</b> in the <b>pipeline</b> and login to hugginface_hub by running
+   ```python
+   import huggingface_hub
+   huggingface_hub.login(<ACCES_TOKEN>)
+   ```
+   - Or directly pass your <ACCES_TOKEN> to <b>token</b> in the <b>pipeline</b>
 ```python
-import torch
 from transformers import pipeline
 
 generate_text = pipeline(
@@ -21,6 +24,7 @@ generate_text = pipeline(
     trust_remote_code=True,
     use_fast={{use_fast}},
     device_map={"": "cuda:0"},
+    token=True,
 )
 
 res = generate_text(

--- a/experiment_summary_code_template.md
+++ b/experiment_summary_code_template.md
@@ -1,6 +1,8 @@
 ### Usage with HF transformers
 
-To use the model with the `transformers` library on a machine with GPUs, first make sure you have the `transformers`, `accelerate` and `torch` libraries installed.
+To use the model with the <b>`transformers`</b> library on a machine with GPUs:
+- First, push the model to a huggingface repo by clicking the <b>Push checkpoint to huggingface</b> button below
+- Make sure you have the <b>`transformers`</b>, <b>`accelerate`</b> and <b>`torch`</b> libraries installed in the machine's environment
 
 ```bash
 pip install transformers=={{transformers_version}}
@@ -8,7 +10,7 @@ pip install einops=={{einops_version}}
 pip install accelerate=={{accelerate_version}}
 pip install torch=={{torch_version}}
 ```
-
+- Pass model path from the huggingface repo to the following pipeline
 ```python
 import torch
 from transformers import pipeline

--- a/experiment_summary_code_template.md
+++ b/experiment_summary_code_template.md
@@ -1,0 +1,35 @@
+### Usage with :joy: transformers
+
+To use the model with the `transformers` library on a machine with GPUs, first make sure you have the `transformers`, `accelerate` and `torch` libraries installed.
+
+```bash
+pip install transformers=={{transformers_version}}
+pip install einops=={{einops_version}}
+pip install accelerate=={{accelerate_version}}
+pip install torch=={{torch_version}}
+```
+
+```python
+import torch
+from transformers import pipeline
+
+generate_text = pipeline(
+    model="{{repo_id}}",
+    torch_dtype="auto",
+    trust_remote_code=True,
+    use_fast={{use_fast}},
+    device_map={"": "cuda:0"},
+)
+
+res = generate_text(
+    "Why is drinking water so healthy?",
+    min_new_tokens={{min_new_tokens}},
+    max_new_tokens={{max_new_tokens}},
+    do_sample={{do_sample}},
+    num_beams={{num_beams}},
+    temperature=float({{temperature}}),
+    repetition_penalty=float({{repetition_penalty}}),
+    renormalize_logits=True
+)
+print(res[0]["generated_text"])
+```

--- a/experiment_summary_code_template.md
+++ b/experiment_summary_code_template.md
@@ -1,4 +1,4 @@
-### Usage with :joy: transformers
+### Usage with HF transformers
 
 To use the model with the `transformers` library on a machine with GPUs, first make sure you have the `transformers`, `accelerate` and `torch` libraries installed.
 

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -1,7 +1,7 @@
 import multiprocessing
 import os
 from dataclasses import dataclass, field
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import torch
 
@@ -459,6 +459,23 @@ class ConfigNLPCausalLMLogging(DefaultConfig):
 
 
 @dataclass
+class ConfigNLPCausalLMHF(DefaultConfig):
+    account_name: str = ""
+    model_name: str = ""
+
+    @property
+    def repo_id(self) -> Optional[str]:
+        if self.account_name != "" and self.model_name != "":
+            return f"{self.account_name}/{self.model_name}"
+        else:
+            return None
+
+    def __post_init__(self):
+        super().__post_init__()
+        self._visibility = {k: -1 for k in self.__dict__}
+
+
+@dataclass
 class ConfigProblemBase(DefaultConfig):
     output_directory: str = f"output/{os.path.basename(__file__).split('.')[0]}"
     experiment_name: str = field(default_factory=generate_experiment_name)
@@ -483,6 +500,8 @@ class ConfigProblemBase(DefaultConfig):
         default_factory=ConfigNLPCausalLMEnvironment
     )
     logging: ConfigNLPCausalLMLogging = field(default_factory=ConfigNLPCausalLMLogging)
+
+    hf: ConfigNLPCausalLMHF = field(default_factory=ConfigNLPCausalLMHF)
 
     def __post_init__(self):
         super().__post_init__()
@@ -538,4 +557,5 @@ class ConfigProblemBase(DefaultConfig):
                 cfg_dict.get("environment", {})
             ),
             logging=ConfigNLPCausalLMLogging.from_dict(cfg_dict.get("logging", {})),
+            hf=ConfigNLPCausalLMHF.from_dict(cfg_dict.get("hf", {})),
         )

--- a/model_card_template.md
+++ b/model_card_template.md
@@ -19,17 +19,21 @@ This model was trained using [H2O LLM Studio](https://github.com/h2oai/h2o-llmst
 
 ## Usage
 
-To use the model with the `transformers` library on a machine with GPUs, first make sure you have the `transformers`, `accelerate` and `torch` libraries installed.
+To use the model with the `transformers` library on a machine with GPUs, first make sure you have the `transformers` library installed.
 
 ```bash
 pip install transformers=={{transformers_version}}
-pip install einops=={{einops_version}}
-pip install accelerate=={{accelerate_version}}
-pip install torch=={{torch_version}}
 ```
 
+Also make sure you are providing your huggingface token to the pipeline if the model is lying in a private repo.
+    - Either leave `token=True` in the `pipeline` and login to hugginface_hub by running
+        ```python
+        import huggingface_hub
+        huggingface_hub.login(<ACCES_TOKEN>)
+        ```
+    - Or directly pass your <ACCES_TOKEN> to `token` in the `pipeline`
+
 ```python
-import torch
 from transformers import pipeline
 
 generate_text = pipeline(
@@ -38,6 +42,7 @@ generate_text = pipeline(
     trust_remote_code=True,
     use_fast={{use_fast}},
     device_map={"": "cuda:0"},
+    token=True,
 )
 
 res = generate_text(
@@ -66,7 +71,6 @@ print(generate_text.preprocess("Why is drinking water so healthy?")["prompt_text
 Alternatively, you can download [h2oai_pipeline.py](h2oai_pipeline.py), store it alongside your notebook, and construct the pipeline yourself from the loaded model and tokenizer. If the model and the tokenizer are fully supported in the `transformers` package, this will allow you to set `trust_remote_code=False`.
 
 ```python
-import torch
 from h2oai_pipeline import H2OTextGenerationPipeline
 from transformers import AutoModelForCausalLM, AutoTokenizer
 


### PR DESCRIPTION
This PR introduces new Experiment Summary cards
- New Summary page includes stats cards to highlight experiments’ main configurations and scores.
- The cards are grouped by the titles of Experiment, Datasets, Score, and Main Configurations.
    - Thought it would be useful to highlight the most important settings of an experiment.
    - (We can expand or replace some of them. Please let me know in the comments) 
- Now there is also a code card that shows how to interact with the experiment model via the HF transformers package.
    - If a model is not pushed to an HF repo yet, the “**model**” attribute in the code pipeline will be shown as “**account/model**”
    - Otherwise, **the actual HF model path** will be put in place.
    - To store HF repo info after pushing models, introduced a new config subclass: **ConfigNLPCausalLMHF**
    - (We might also consider displaying the code card only when the model is pushed to HF, wonder what you’d prefer?)

## How it looks
<img width="1389" alt="image" src="https://github.com/h2oai/h2o-llmstudio/assets/70659545/492c54ea-694e-4ce9-b165-ac0f37f7eb58">


Hope you find it useful and please feel free to let me know if there is anything you'd like to change/add to the PR 🙌 