### PR TITLE
HF friendly repo name

### DIFF
--- a/app_utils/sections/experiment.py
+++ b/app_utils/sections/experiment.py
@@ -34,6 +34,7 @@ from app_utils.utils import (
     get_problem_types,
     get_ui_elements,
     get_unique_name,
+    hf_repo_friendly_name,
     parse_ui_elements,
     remove_model_type,
     set_env,
@@ -1631,7 +1632,9 @@ async def experiment_push_to_huggingface_dialog(q: Q, error: str = ""):
             ui.textbox(
                 name="experiment/display/push_to_huggingface/model_name",
                 label="Model Name",
-                value=q.client["experiment/display/experiment"].name.replace(".", "-"),
+                value=hf_repo_friendly_name(
+                    q.client["experiment/display/experiment"].name
+                ),
                 width="500px",
                 required=True,
                 tooltip="The name of the model as shown on HF.",

--- a/app_utils/utils.py
+++ b/app_utils/utils.py
@@ -8,6 +8,7 @@ import logging
 import math
 import os
 import pickle
+import re
 import shutil
 import socket
 import subprocess
@@ -1974,3 +1975,19 @@ def set_env(**environ):
     finally:
         os.environ.clear()
         os.environ.update(old_environ)
+
+
+def hf_repo_friendly_name(name: str) -> str:
+    """
+    Converts the given string into a huggingface-repository-friendly name.
+
+    • Repo id must use alphanumeric chars or '-', '_', and '.' allowed.
+    • '--' and '..' are forbidden
+    • '-' and '.' cannot start or end the name
+    • max length is 96
+    """
+    name = re.sub("[^0-9a-zA-Z]+", "-", name)
+    name = name[1:] if name.startswith("-") else name
+    name = name[:-1] if name.endswith("-") else name
+    name = name[:96]
+    return name


### PR DESCRIPTION
As someone who is used to naming experiments and datasets with at least " " (spaces), I'm frequently running into a wrong naming error when I want to push a model to hf. (I can easily forget to rename it on the fly and it takes some time till hitting the error)

With this PR, I'm aiming for the ultimate first name suggestion that'll comply with all the HF naming rules 😄 

**Example**
Weird experiment name: **delete me we56rd chars...--as-**
HF-friendly suggestion: **delete-me-we56rd-chars-as**

