### PR TITLE
Fix get_size_str

### DIFF
--- a/llm_studio/src/utils/export_utils.py
+++ b/llm_studio/src/utils/export_utils.py
@@ -142,7 +142,7 @@ def get_size_str(
 
     act_i = 0
     if output_unit == "dynamic":
-        while x >= 1024 and act_i < len(names):
+        while x >= 1024 and act_i < len(names) - 1:
             x /= 1024
             act_i += 1
     else:

--- a/tests/utils/test_export_utils.py
+++ b/tests/utils/test_export_utils.py
@@ -1,0 +1,19 @@
+from llm_studio.src.utils.export_utils import get_size_str
+
+
+def test_get_size_atomic_units():
+    assert get_size_str(1, input_unit="B") == "1 B"
+    assert get_size_str(1024, input_unit="B", output_unit="KB") == "1.0 KB"
+    assert get_size_str(1048576, input_unit="B", output_unit="MB") == "1.0 MB"
+    assert get_size_str(1073741824, input_unit="B", output_unit="GB") == "1.0 GB"
+    assert get_size_str(1099511627776, input_unit="B", output_unit="TB") == "1.0 TB"
+
+    assert get_size_str(1024**5) == "1024.0 TB"
+
+
+def test_get_size_str_dynamic():
+    assert get_size_str(1500, input_unit="B", output_unit="dynamic") == "1.46 KB"
+    assert (
+        get_size_str(1500, sig_figs=3, input_unit="B", output_unit="dynamic")
+        == "1.465 KB"
+    )


### PR DESCRIPTION
`get_size_str` breaks when disc input size >= 1PB. While this limit should not be a concern for all practical purposes, a user did report an [issue](https://github.com/h2oai/h2o-llmstudio/issues/352).

This PR fixes `get_size_str` to work with arbitrary input sizes.

Fixes #352 