### PR TITLE
conversation chaining refactoring

### DIFF
--- a/app_utils/sections/chat.py
+++ b/app_utils/sections/chat.py
@@ -239,7 +239,7 @@ async def chat_update(q: Q) -> None:
 
     def text_cleaner(text: str) -> str:
         return cfg.dataset.dataset_class.clean_output(
-            output={"predicted_text": np.array([text])}, prompts=[full_prompt], cfg=cfg
+            output={"predicted_text": np.array([text])}, cfg=cfg
         )["predicted_text"][0]
 
     if cfg.prediction.num_beams == 1:

--- a/llm_studio/src/datasets/conversation_chain_handler.py
+++ b/llm_studio/src/datasets/conversation_chain_handler.py
@@ -1,0 +1,130 @@
+import logging
+
+import numpy as np
+
+from llm_studio.src.datasets.text_utils import get_texts
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationChainHandler:
+    """
+    Partitions the dataset into conversation chains.
+    The conversation chains consists of a list of conversations, where each conversation round consists of
+    a triple of (system, prompt, answer).
+    """
+
+    def __init__(self, df, cfg, parser=None):
+        self.parser = parser
+
+        if cfg.dataset.parent_id_column != "None":
+            assert (
+                "id" in df.columns
+            ), f"id column required for conversation chaining, DataFrame only has {df.columns}."
+            sample_ids = (
+                df["id"].astype(df[cfg.dataset.parent_id_column].dtype).tolist()
+            )
+            parent_ids = df[cfg.dataset.parent_id_column].tolist()
+
+            id2parent_id = {
+                id: parent_id
+                for id, parent_id in zip(sample_ids, parent_ids)
+                if parent_id not in [None, "None"]
+                and (
+                    not isinstance(parent_id, float)
+                    or (not np.isnan(parent_id) and not np.isinf(parent_id))
+                )
+            }
+            if cfg.dataset.limit_chained_samples:
+                conversation_start_ids = [
+                    idx for idx in sample_ids if idx not in id2parent_id.values()
+                ]
+            else:
+                conversation_start_ids = sample_ids
+
+            conversation_ids_lists = [
+                self.get_conversation_ids(id2parent_id, conversation_start_id)
+                for conversation_start_id in conversation_start_ids
+            ]
+            # map from df["id"] to enumeration index
+            dataframeid2idx = {id: idx for idx, id in enumerate(sample_ids)}
+            self.conversation_ids_lists = [
+                [
+                    dataframeid2idx[conversation_id]
+                    for conversation_id in conversation_ids
+                ]
+                for conversation_ids in conversation_ids_lists
+            ]
+        else:
+            # no parent id column, so each sample is a conversation chain
+            self.conversation_ids_lists = [[idx] for idx in range(len(df))]
+
+        self.prompts = get_texts(df, cfg, separator="")
+        if cfg.dataset.answer_column in df.columns:
+            self.answers = df[cfg.dataset.answer_column].astype(str).tolist()
+        else:
+            self.answers = ["" for _ in range(len(self.prompts))]
+        self.systems = ["" for _ in range(len(self.prompts))]
+
+        if cfg.dataset.system_column != "None":
+            if cfg.dataset.system_column not in df.columns:
+                logger.warning(
+                    f"System column {cfg.dataset.system_column} not found."
+                    f"Disabling functionality."
+                )
+            else:
+                self.systems = df[cfg.dataset.system_column].astype(str).tolist()
+
+    @staticmethod
+    def get_conversation_ids(id2parent_id, start_id):
+        """
+        Gets the conversation chain for a given starting conversation ID.
+        Args:
+            id2parent_id: A dictionary containing the mapping of IDs to its previous parent ID.
+            start_id: The ID of the starting conversation in the chain.
+        Returns:
+            A list of conversation IDs representing the conversation chain. The chain is ordered from the
+            starting conversation to the last conversation in the chain.
+        """
+        loop_counter = 0  # prevent infinite loops in case of circular parent chains (dataframe issue)
+
+        conversation_chain_ids = [start_id]
+        parent_id = start_id
+        while parent_id in id2parent_id:
+            loop_counter += 1
+            # get next parent id
+            parent_id = id2parent_id[parent_id]
+            conversation_chain_ids.append(parent_id)
+            if loop_counter > 1000:
+                raise ValueError(
+                    f"Parent chain of sample with idx {start_id} exceeds max loop count of 1000. "
+                    f"Please ensure that parent chain is not circular."
+                )
+        return conversation_chain_ids[::-1]
+
+    def __len__(self):
+        return len(self.conversation_ids_lists)
+
+    def __getitem__(self, idx):
+        """
+        Gets a single conversation chain.
+        The conversation may be:
+        - a single (system, prompt, answer) round,
+          if cfg.dataset.parent_id_column == "None" or there is no parent_id for the conversation
+        - a conversation potentially starting somewhere in the middle of the conversation,
+          if the conversation is chained and limit_chained_samples is set to False
+        - always a complete conversation, if the conversation is chained
+          and limit_chained_samples is True
+
+        """
+        prompts = [self.prompts[i] for i in self.conversation_ids_lists[idx]]
+        answers = [self.answers[i] for i in self.conversation_ids_lists[idx]]
+        systems = [self.systems[i] for i in self.conversation_ids_lists[idx]]
+        text_dict = {
+            "prompts": prompts,
+            "answers": answers,
+            "systems": systems,
+        }
+        if self.parser:
+            text_dict = self.parser(text_dict)
+        return text_dict

--- a/llm_studio/src/datasets/conversation_chain_handler.py
+++ b/llm_studio/src/datasets/conversation_chain_handler.py
@@ -83,8 +83,8 @@ class ConversationChainHandler:
             f"DataFrame only has {df.columns}."
         )
         # sample and parent ids can have any dtype, such as str, int, float, etc.
-        # id column can be int, while parent_id column can be float (as some values are NaN)
-        # so we cast id to the same dtype
+        # id column can be int, while parent_id column can be float
+        # (as some values are NaN) so we cast id to the same dtype
         sample_ids = df["id"].astype(df[cfg.dataset.parent_id_column].dtype).tolist()
         parent_ids = df[cfg.dataset.parent_id_column].tolist()
 

--- a/llm_studio/src/datasets/conversation_chain_handler.py
+++ b/llm_studio/src/datasets/conversation_chain_handler.py
@@ -73,7 +73,7 @@ class ConversationChainHandler:
             self.systems = ["" for _ in range(len(self.prompts))]
 
     def get_conversation_chain_ids(self, cfg, df):
-        if cfg.dataset.parent_id_column == "None":
+        if cfg.dataset.parent_id_column in ["None", None]:
             # no parent id column, so each triplet (system_i, prompt_i, answer_i)
             # is a conversation chain
             return [[idx] for idx in range(len(df))]

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -85,11 +85,10 @@ class CustomDataset(Dataset):
                 )
             ]
         )
-        prompt_attention_mask = torch.ones_like(prompt_input_ids)
         sample.update(
             self.pad_tokens(
                 prompt_input_ids,
-                attention_mask=prompt_attention_mask,
+                attention_mask=torch.ones_like(prompt_input_ids),
                 max_length=self.cfg.tokenizer.max_length,
                 pad_token_id=self.tokenizer.pad_token_id,
                 prefix="prompt_",

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -569,20 +569,15 @@ class CustomDataset(Dataset):
     def get_chained_prompt_text_list(self, idx) -> List[str]:
         text_separator = "TEXT_SEPARATOR"
         text_dict = self.conversation_chain_handler[idx]
-        # system_prompt == Start of conversation
         chat_history = "".join(
             [
                 prompt + text_separator + answer + text_separator
                 for prompt, answer in zip(
-                    text_dict["prompt"][:-1], text_dict["answer"][:-1]
+                    text_dict["prompts"][:-1], text_dict["answers"][:-1]
                 )
             ]
         )
-
-        # system prompt may be an empty string
-        prompt_text = (
-            text_dict["system_prompt"][0] + chat_history + text_dict["prompt"][-1]
-        )
+        prompt_text = text_dict["systems"][0] + chat_history + text_dict["prompts"][-1]
         return prompt_text.split(text_separator)
 
     def pad_tokens(

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -498,7 +498,7 @@ class CustomDataset(Dataset):
         """
         encodings = [
             self._get_sample_encoding(system, prompt, answer)
-            for idx, (prompt, answer, system) in enumerate(
+            for idx, (system, prompt, answer) in enumerate(
                 zip(
                     input_text_dict["systems"],
                     input_text_dict["prompts"],
@@ -516,12 +516,16 @@ class CustomDataset(Dataset):
                 if np.random.random() > self.cfg.augmentation.skip_parent_probability
             ]
             # randomly replace parent with another parent
-            if np.random.random() > self.cfg.augmentation.random_parent_probability:
+            if np.random.random() < self.cfg.augmentation.random_parent_probability:
                 idx = np.random.randint(len(self.conversation_chain_handler.prompts))
                 parent_encodings = [
                     self._get_sample_encoding(
-                        self.conversation_chain_handler.systems[idx],
-                        self.conversation_chain_handler.prompts[idx],
+                        self.parse_system(
+                            self.cfg, self.conversation_chain_handler.systems[idx]
+                        ),
+                        self.parse_prompt(
+                            self.cfg, self.conversation_chain_handler.prompts[idx]
+                        ),
                         self.conversation_chain_handler.answers[idx],
                     )
                 ] + parent_encodings[1:]

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -13,97 +13,84 @@ from llm_studio.src.datasets.text_utils import get_texts, get_tokenizer
 logger = logging.getLogger(__name__)
 
 
-class CustomDataset(Dataset):
-    """Base PyTorch dataset for any problem type."""
+class ConversationChainHandler:
+    """
 
-    def __init__(self, df: pd.DataFrame, cfg: Any, mode: str = "train"):
-        """
-        Args:
-            df: input DataFrame
-            cfg: config with all the hyperparameters
-            mode: dataset mode. One of {"train", "validation"}
-        """
+    ConversationChainHandler
+    Handles conversation chains and provides methods for retrieving chained prompt text.
+    """
 
-        self.cfg = cfg
-        self.mode = mode
-        self.df = df.copy()
+    def __init__(self, df, cfg):
+        if not hasattr(cfg, "_tokenizer_eos_token"):
+            get_tokenizer(cfg)
 
-        self.indices = np.arange(len(self.df))
-
-        assert self.mode in [
-            "train",
-            "validation",
-        ], f"There is no {self.mode} for the datasets"
-
-        # Get the labels
-        has_all_columns = cfg.dataset.answer_column in self.df.columns
-        has_missing_values = False
-        if has_all_columns:
-            has_missing_values = (
-                self.df.shape[0]
-                != self.df[[cfg.dataset.answer_column]].dropna().shape[0]
-            )
-
-        if not has_all_columns or has_missing_values:
-            if has_missing_values:
-                message = (
-                    f"The {self.mode} DataFrame"
-                    f" column {cfg.dataset.answer_column}"
-                    " contain missing values."
-                )
+        if cfg.dataset.parent_id_column != "None":
+            id2children_id = {
+                parent_id: id
+                for id, parent_id in zip(df["id"], df[cfg.dataset.parent_id_column])
+            }
+            if cfg.dataset.limit_chained_samples:
+                conversation_start_ids = [
+                    idx for idx in df["id"].values if idx not in id2children_id
+                ]
             else:
-                message = (
-                    f"The {self.mode} DataFrame "
-                    "does not contain the required column:"
-                    f" {cfg.dataset.answer_column}."
-                )
+                conversation_start_ids = df["id"].values
 
-            raise ValueError(message)
-
-        self.tokenizer = get_tokenizer(cfg)
+            self.conversation_ids = [
+                self._get_children_ids(id2children_id, conversation_start_id)
+                for conversation_start_id in conversation_start_ids
+            ]
+        else:
+            self.conversation_ids = [[idx] for idx in df.id]
 
         self.prompts = [
             self.parse_prompt(cfg, prompt)
             for prompt in get_texts(df, self.cfg, separator="")
         ]
 
-        self.answers = (
-            self.df[self.cfg.dataset.answer_column].astype(str).values.tolist()
-        )
+        self.answers = df[cfg.dataset.answer_column].astype(str).tolist()
+        self.systems = ["" for _ in range(len(self.prompts))]
 
-        self.parent_ids = None
-        if self.cfg.dataset.parent_id_column != "None":
-            if "id" not in self.df.columns:
+        if cfg.dataset.system_column != "None":
+            if cfg.dataset.system_column not in df.columns:
                 logger.warning(
-                    f"When using parent column, the dataframe requires an 'id' column. "
-                    f"Disabling functionality for mode {self.mode}."
+                    f"System column {cfg.dataset.system_column} not found."
+                    f"Disabling functionality."
                 )
             else:
-                self.parent_ids = self.df[self.cfg.dataset.parent_id_column].values
-                self.df_id_to_idx = {v: k for k, v in enumerate(self.df["id"].values)}
+                self.systems = [
+                    self.parse_system(cfg, system)
+                    for system in df[cfg.dataset.system_column].astype(str).tolist()
+                ]
 
-                # limit chained samples to the longest chain
-                if self.cfg.dataset.limit_chained_samples and self.mode == "train":
-                    unique_parent_ids = set(self.parent_ids)
-                    self.indices = self.indices[
-                        [id not in unique_parent_ids for id in self.df["id"].values]
-                    ]
+    def __len__(self):
+        return len(self.conversation_ids)
 
-        self.systems = None
-        if self.cfg.dataset.system_column != "None":
-            if self.cfg.dataset.system_column not in self.df.columns:
-                logger.warning(
-                    f"System column {self.cfg.dataset.system_column} not found."
-                    f"Disabling functionality for mode {self.mode}."
-                )
-            else:
-                systems = (
-                    self.df[self.cfg.dataset.system_column].astype(str).values.tolist()
-                )
-                self.systems = [self.parse_system(cfg, system) for system in systems]
+    def __getitem__(self, idx):
+        """
+        Gets a single conversation chain.
+        Args:
+            idx:
 
-        if self.cfg.environment._local_rank == 0:
-            logger.info(f"Sample prompt: {self.prompts[0]}")
+        Returns:
+
+        """
+        prompts = [self.prompts[i] for i in self.conversation_ids[idx]]
+        answers = [self.answers[i] for i in self.conversation_ids[idx]]
+        systems = [self.systems[i] for i in self.conversation_ids[idx]]
+        return {
+            "prompts": prompts,
+            "answers": answers,
+            "systems": systems,
+        }
+
+    def _get_children_ids(self, id2children_id, start_id):
+        children_ids = [start_id]
+        current_id = start_id
+        while current_id in id2children_id:
+            current_id = id2children_id[current_id]
+            children_ids.append(current_id)
+        return children_ids
 
     @staticmethod
     def parse_prompt(cfg: Any, prompt: str):
@@ -130,20 +117,103 @@ class CustomDataset(Dataset):
             system += cfg._tokenizer_eos_token
         return system
 
+
+class CustomDataset(Dataset):
+    """Base PyTorch dataset for any problem type."""
+
+    def __init__(self, df: pd.DataFrame, cfg: Any, mode: str = "train"):
+        """
+        Args:
+            df: input DataFrame
+            cfg: config with all the hyperparameters
+            mode: dataset mode. One of {"train", "validation"}
+        """
+        assert mode in [
+            "train",
+            "validation",
+        ], f"There is no {mode} for the datasets"
+
+        self.cfg = cfg
+        self.mode = mode
+        self.df = df.copy()
+
+        self.tokenizer = get_tokenizer(self.cfg)
+        self.conversation_chain_handler = ConversationChainHandler(self.df, self.cfg)
+        if cfg.environment._local_rank == 0:
+            text_dict = self.conversation_chain_handler[0]
+            logger.info(f"Sample prompt: " f"{text_dict['prompts'][0]} ")
+
     def __len__(self) -> int:
-        return len(self.indices)
+        return len(self.conversation_chain_handler)
+
+    def __getitem__(self, idx: int) -> Dict:
+        """Reads a single text observation."""
+        input_text_dict = self.conversation_chain_handler[idx]
+
+        sample = dict()
+        encodings, system_encoding = self.get_encodings(input_text_dict=input_text_dict)
+
+        input_ids = torch.cat([torch.cat(encoding) for encoding in encodings])
+        sample.update(self.get_labels(encodings))
+        sample.update(
+            self.pad_tokens(
+                input_ids,
+                attention_mask=torch.ones_like(input_ids),
+                max_length=self.cfg.tokenizer.max_length,
+                pad_token_id=self.tokenizer.pad_token_id,
+            )
+        )
+
+        # get answer encodings
+        answer_input_ids = encodings[-1][1]
+        answer_attention_mask = torch.ones_like(answer_input_ids)
+
+        sample.update(
+            self.pad_tokens(
+                answer_input_ids,
+                attention_mask=answer_attention_mask,
+                max_length=self.cfg.tokenizer.max_length_answer,
+                pad_token_id=self.tokenizer.pad_token_id,
+                direction="right",
+                prefix="answer_",
+            )
+        )
+
+        # Remove last answer from encoding to create the prompt for inference
+        encodings[-1][1] = torch.empty(0)
+        prompt_input_ids = torch.cat([torch.cat(encoding) for encoding in encodings])
+        prompt_attention_mask = torch.ones_like(prompt_input_ids)
+        sample.update(
+            self.pad_tokens(
+                prompt_input_ids,
+                attention_mask=prompt_attention_mask,
+                max_length=self.cfg.tokenizer.max_length,
+                pad_token_id=self.tokenizer.pad_token_id,
+                prefix="prompt_",
+            )
+        )
+
+        # make sure system encoding is always prepended if max_length exceeded
+        if sample["input_ids"][0] != self.tokenizer.pad_token_id:
+            sample["input_ids"][: len(system_encoding)] = system_encoding
+            if self.cfg.dataset.mask_prompt_labels:
+                sample["labels"][: len(system_encoding)] = -100
+        if sample["prompt_input_ids"][0] != self.tokenizer.pad_token_id:
+            sample["prompt_input_ids"][: len(system_encoding)] = system_encoding
+        return sample
 
     @staticmethod
-    def get_input_columns(cfg: Any) -> Tuple[str, ...]:
-        """Assigns the input columns
-
-        Args:
-            cfg: config
-
-        """
-        if isinstance(cfg.dataset.prompt_column, tuple):
-            return cfg.dataset.prompt_column
-        return (cfg.dataset.prompt_column,)
+    def parse_prompt(cfg: Any, prompt: str):
+        prompt = (
+            f"{codecs.decode(cfg.dataset.text_prompt_start, 'unicode_escape')}{prompt}"
+        )
+        if cfg.dataset.add_eos_token_to_prompt:
+            prompt += cfg._tokenizer_eos_token
+        prompt = (
+            f"{prompt}"
+            f"{codecs.decode(cfg.dataset.text_answer_separator, 'unicode_escape')}"
+        )
+        return prompt
 
     @staticmethod
     def batch_to_device(
@@ -254,7 +324,6 @@ class CustomDataset(Dataset):
     @staticmethod
     def clean_output(
         output: Dict,
-        prompts: List[str],
         cfg: Any,
     ):
         output["predicted_text"] = output["predicted_text"].tolist()
@@ -269,7 +338,7 @@ class CustomDataset(Dataset):
 
     def postprocess_output(self, cfg, df: pd.DataFrame, output: Dict) -> Dict:
         if not cfg.prediction.metric == "Perplexity":
-            output = self.clean_output(output, self.prompts, cfg)
+            output = self.clean_output(output, cfg)
 
         output["target_text"] = self.answers
 
@@ -336,59 +405,19 @@ class CustomDataset(Dataset):
                 "Please ensure that some parent ids are empty."
             )
 
-    def __getitem__(self, idx: int) -> Dict:
-        """Reads a single text observation."""
-        idx = self.indices[idx]
-
-        sample = dict()
-        encodings, system_encoding = self.get_encodings(idx)
-        input_ids = torch.cat([torch.cat(encoding) for encoding in encodings])
-        sample.update(self.get_labels(encodings))
-        sample.update(
-            self.pad_tokens(
-                input_ids,
-                attention_mask=torch.ones_like(input_ids),
-                max_length=self.cfg.tokenizer.max_length,
-                pad_token_id=self.tokenizer.pad_token_id,
-            )
+        assert cfg.dataset.answer_column in df.columns, (
+            f"Answer column {cfg.dataset.answer_column} not found in the "
+            f"{mode} DataFrame."
         )
-
-        # get answer encodings
-        answer_input_ids = encodings[-1][1]
-        answer_attention_mask = torch.ones_like(answer_input_ids)
-
-        sample.update(
-            self.pad_tokens(
-                answer_input_ids,
-                attention_mask=answer_attention_mask,
-                max_length=self.cfg.tokenizer.max_length_answer,
-                pad_token_id=self.tokenizer.pad_token_id,
-                direction="right",
-                prefix="answer_",
-            )
+        assert df.shape[0] == df[[cfg.dataset.answer_column]].dropna().shape[0], (
+            f"The {mode} DataFrame"
+            f" column {cfg.dataset.answer_column}"
+            " contains missing values."
         )
-
-        # Remove last answer from encoding to create the prompt for inference
-        encodings[-1][1] = torch.empty(0)
-        prompt_input_ids = torch.cat([torch.cat(encoding) for encoding in encodings])
-        prompt_attention_mask = torch.ones_like(prompt_input_ids)
-        sample.update(
-            self.pad_tokens(
-                prompt_input_ids,
-                attention_mask=prompt_attention_mask,
-                max_length=self.cfg.tokenizer.max_length,
-                pad_token_id=self.tokenizer.pad_token_id,
-                prefix="prompt_",
-            )
-        )
-        # make sure system encoding is always prepended if max_length exceeded
-        if sample["input_ids"][0] != self.tokenizer.pad_token_id:
-            sample["input_ids"][: len(system_encoding)] = system_encoding
-            if self.cfg.dataset.mask_prompt_labels:
-                sample["labels"][: len(system_encoding)] = -100
-        if sample["prompt_input_ids"][0] != self.tokenizer.pad_token_id:
-            sample["prompt_input_ids"][: len(system_encoding)] = system_encoding
-        return sample
+        if cfg.dataset.parent_id_column != "None":
+            assert (
+                "id" in df.columns
+            ), "When using parent column, the dataframe requires an 'id' column. "
 
     def get_labels(self, encodings):
         labels = torch.cat([torch.cat(encoding) for encoding in encodings]).clone()
@@ -416,13 +445,39 @@ class CustomDataset(Dataset):
         sample["labels"][-len(labels) :] = labels
         return sample
 
-    def get_encodings(self, idx):
-        system_encoding, prompt_encoding, answer_encoding = self._get_sample_encoding(
-            idx
-        )
-        encodings = [[system_encoding, prompt_encoding, answer_encoding]]
-        encodings = self.get_parent_encodings(idx) + encodings
-        # in case of chained samples, we only want to keep the first system encoding
+    def get_encodings(self, input_text_dict):
+        encodings = [
+            self._get_sample_encoding(system, prompt, answer)
+            for idx, (prompt, answer, system) in enumerate(
+                zip(
+                    input_text_dict["system"],
+                    input_text_dict["prompt"],
+                    input_text_dict["answer"],
+                )
+            )
+        ]
+
+        if self.mode == "train":
+            parent_encodings = encodings[:-1]
+            # randomly replace parent with another parent
+            parent_encodings = [
+                encoding
+                if np.random.random() > self.cfg.augmentation.replace_parent_probability
+                else self._get_sample_encoding(
+                    self.conversation_chain_handler.systems[idx],
+                    self.conversation_chain_handler.prompts[idx],
+                    self.conversation_chain_handler.answers[idx],
+                )
+                for idx, encoding in enumerate(parent_encodings)
+            ]
+            # randomly skip parent
+            parent_encodings = [
+                encoding
+                for idx, encoding in enumerate(parent_encodings)
+                if np.random.random() > self.cfg.augmentation.skip_parent_probability
+            ]
+            encodings = parent_encodings + [encodings[-1]]
+
         system_encoding = encodings[0][0]
         # remove system encodings from list of encodings to only keep prompt and answer
         encodings = [encoding[1:] for encoding in encodings]
@@ -430,24 +485,19 @@ class CustomDataset(Dataset):
         encodings[0][0] = torch.cat([system_encoding, encodings[0][0]])
         return encodings, system_encoding
 
-    def _get_sample_encoding(self, idx) -> List:
-        if self.systems is not None:
-            system = self.systems[idx]
+    def _get_sample_encoding(self, system: str, prompt: str, answer: str) -> List:
+        if len(system) > 0:
             system_encoding = self.encode(
                 self.tokenizer, system, self.cfg.tokenizer.max_length_prompt, "right"
             )["input_ids"]
         else:
             system_encoding = torch.empty(0)
-        prompt = self.prompts[idx]
-        answer = self.answers[idx]
-
         prompt_encoding = self.encode(
             self.tokenizer, prompt, self.cfg.tokenizer.max_length_prompt, "left"
         )["input_ids"]
-        if self.cfg.dataset.add_eos_token_to_answer:
-            max_length_answer = self.cfg.tokenizer.max_length_answer - 1
-        else:
-            max_length_answer = self.cfg.tokenizer.max_length_answer
+        max_length_answer = self.cfg.tokenizer.max_length_answer - int(
+            self.cfg.dataset.add_eos_token_to_answer
+        )
         answer_encoding = self.encode(
             self.tokenizer, answer, max_length_answer, "right"
         )["input_ids"]
@@ -462,42 +512,28 @@ class CustomDataset(Dataset):
 
         return [system_encoding, prompt_encoding, answer_encoding]
 
-    def get_parent_ids(self, idx):
-        max_loop = 1_000
-        parent_idxs = []
-        if self.parent_ids is not None:
-            parent_idx = idx
-            while (
-                (parent_idx := self.df_id_to_idx.get(self.parent_ids[parent_idx], None))
-            ) is not None:
-                parent_idxs.append(parent_idx)
-                max_loop -= 1
-                if max_loop == 0:
-                    raise ValueError(
-                        f"Parent chain of sample with idx {idx} "
-                        f"exceeds max loop count. "
-                        f"Please ensure that parent chain is not circular."
-                    )
-        return parent_idxs[::-1]
-
-    def get_parent_encodings(self, idx):
-        parent_encodings = [
-            self._get_sample_encoding(int(parent_idx))
-            for parent_idx in self.get_parent_ids(idx)
-        ]
-        if self.mode == "train":
-            # Note that if condition is called for each parent encoding,
-            # thus the probability is not the same for each parent encoding.
-            parent_encodings = [
-                parent_encoding
-                for parent_encoding in parent_encodings
-                if not np.random.random()
-                < self.cfg.augmentation.skip_parent_probability
+    def get_chained_prompt_text_list(self, idx) -> List[str]:
+        text_separator = "TEXT_SEPARATOR"
+        text_dict = self.conversation_chain_handler[idx]
+        # system_prompt == Start of conversation
+        system_prompt = text_dict["system_prompt"][0]
+        history = "".join(
+            [
+                prompt + text_separator + answer + text_separator
+                for prompt, answer in zip(
+                    text_dict["prompt"][:-1], text_dict["answer"][:-1]
+                )
             ]
-            if np.random.random() < self.cfg.augmentation.random_parent_probability:
-                rnd_idx = np.random.randint(len(self))
-                parent_encodings.insert(0, self._get_sample_encoding(int(rnd_idx)))
-        return parent_encodings
+        )
+
+        prompt_text = ""
+        if system_prompt:
+            # No text separator as system prompt is part of the prompt
+            prompt_text += system_prompt
+        if history:
+            prompt_text += history
+        prompt_text += text_dict["prompt"][-1]
+        return prompt_text.split(text_separator)
 
     def pad_tokens(
         self,
@@ -507,7 +543,6 @@ class CustomDataset(Dataset):
         pad_token_id,
         direction="left",
         prefix="",
-        system_ids=None,
     ):
         sample = {}
 

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -37,7 +37,12 @@ class CustomDataset(Dataset):
     def __getitem__(self, idx: int) -> Dict:
         """Reads a single text observation."""
         input_text_dict = self.conversation_chain_handler[idx]
-        self.parse_text_dict(input_text_dict)
+        input_text_dict["systems"] = [
+            self.parse_system(self.cfg, system) for system in input_text_dict["systems"]
+        ]
+        input_text_dict["prompts"] = [
+            self.parse_prompt(self.cfg, prompt) for prompt in input_text_dict["prompts"]
+        ]
 
         sample = dict()
         system_encoding, prompt_encodings, answer_encodings = self.get_encodings(
@@ -128,14 +133,6 @@ class CustomDataset(Dataset):
         if cfg.dataset.add_eos_token_to_system:
             system += cfg._tokenizer_eos_token
         return system
-
-    def parse_text_dict(self, input_text_dict):
-        input_text_dict["systems"] = [
-            self.parse_system(self.cfg, system) for system in input_text_dict["systems"]
-        ]
-        input_text_dict["prompts"] = [
-            self.parse_prompt(self.cfg, prompt) for prompt in input_text_dict["prompts"]
-        ]
 
     @staticmethod
     def batch_to_device(

--- a/llm_studio/src/datasets/text_rlhf_modeling_ds.py
+++ b/llm_studio/src/datasets/text_rlhf_modeling_ds.py
@@ -52,3 +52,6 @@ class CustomDataset(CausalLMCustomDataset):
         output["predicted_text"] = np.array(predicted_text)
         output["predicted_answer_ids"] = output["predicted_answer_ids"].detach()
         return output
+
+    def augment_data(self, encodings):
+        return encodings

--- a/llm_studio/src/datasets/text_rlhf_modeling_ds.py
+++ b/llm_studio/src/datasets/text_rlhf_modeling_ds.py
@@ -19,7 +19,6 @@ class CustomDataset(CausalLMCustomDataset):
             cfg.dataset.system_column == "None"
         ), "RLHF is not compatible with system column."
         super().__init__(df, cfg, mode)
-        self.raw_prompts = get_texts(df, self.cfg, separator="")
 
     def __getitem__(self, idx: int) -> Dict:
         """Reads a single text observation."""

--- a/llm_studio/src/utils/data_utils.py
+++ b/llm_studio/src/utils/data_utils.py
@@ -129,9 +129,9 @@ def get_fill_columns(cfg: Any) -> List[str]:
 
 def read_dataframe_drop_missing_labels(path: str, cfg: Any) -> pd.DataFrame:
     if isinstance(cfg.dataset.prompt_column, tuple):
-        input_cols = cfg.dataset.prompt_column
+        input_cols = list(cfg.dataset.prompt_column)
     else:
-        input_cols = (cfg.dataset.prompt_column,)
+        input_cols = [cfg.dataset.prompt_column]
     non_missing_columns = input_cols + [cfg.dataset.answer_column]
     verbose = cfg.environment._local_rank == 0
     fill_columns = get_fill_columns(cfg)

--- a/llm_studio/src/utils/data_utils.py
+++ b/llm_studio/src/utils/data_utils.py
@@ -128,7 +128,10 @@ def get_fill_columns(cfg: Any) -> List[str]:
 
 
 def read_dataframe_drop_missing_labels(path: str, cfg: Any) -> pd.DataFrame:
-    input_cols = list(cfg.dataset.dataset_class.get_input_columns(cfg))
+    if isinstance(cfg.dataset.prompt_column, tuple):
+        input_cols = cfg.dataset.prompt_column
+    else:
+        input_cols = (cfg.dataset.prompt_column,)
     non_missing_columns = input_cols + [cfg.dataset.answer_column]
     verbose = cfg.environment._local_rank == 0
     fill_columns = get_fill_columns(cfg)

--- a/prompt.py
+++ b/prompt.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
             ]
             output["predicted_text"] = np.array(predicted_text)
 
-            output = cfg.dataset.dataset_class.clean_output(output, [prompt], cfg)
+            output = cfg.dataset.dataset_class.clean_output(output, cfg)
 
             output = output["predicted_text"][0]
 

--- a/tests/datasets/test_conversation_chain_handler.py
+++ b/tests/datasets/test_conversation_chain_handler.py
@@ -108,7 +108,7 @@ def test_incomplete_chained_samples(cfg, df_short):
     cfg.dataset.limit_chained_samples = False
 
     handler = ConversationChainHandler(df_short, cfg)
-    assert handler.conversation_ids_lists == [[0], [0, 1], [0, 1, 2], [0, 1, 2, 3]]
+    assert handler.conversation_chain_ids == [[0], [0, 1], [0, 1, 2], [0, 1, 2, 3]]
     assert len(handler) == 4
     for i in range(4):
         assert handler[i] == {
@@ -120,14 +120,14 @@ def test_incomplete_chained_samples(cfg, df_short):
 
 def test_get_conversation_ids():
     # test the get_conversation_ids method - normal case
-    conv_ids = ConversationChainHandler.get_single_conversation_ids(
+    conv_ids = ConversationChainHandler.compute_conversation_history_ids(
         {"id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
     )
     assert conv_ids == ["id1", "id2", "id3", "id4"]
 
     # test the get_conversation_ids method - circular case, should raise ValueError
     with pytest.raises(ValueError):
-        ConversationChainHandler.get_single_conversation_ids(
+        ConversationChainHandler.compute_conversation_history_ids(
             {"id1": "id4", "id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
         )
 
@@ -180,7 +180,7 @@ def df_with_nan():
 
 def test_conversation_chain_handles_nan_parent_ids(df_with_nan, cfg):
     handler = ConversationChainHandler(df_with_nan, cfg)
-    assert handler.conversation_ids_lists == [
+    assert handler.conversation_chain_ids == [
         [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
         [10],
         [11],

--- a/tests/datasets/test_conversation_chain_handler.py
+++ b/tests/datasets/test_conversation_chain_handler.py
@@ -1,0 +1,135 @@
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from llm_studio.src.datasets.text_causal_language_modeling_ds import (
+    ConversationChainHandler,
+)
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame(
+        {
+            "id": ["id1", "id2", "id3", "id4", "x1", "x2", "x3", "x4"],
+            "parent_id": ["None", "id1", "id2", "id3", "None", "x1", "x2", "x3"],
+            "answer": [
+                "answer1",
+                "answer2",
+                "answer3",
+                "answer4",
+                "a1",
+                "a2",
+                "a3",
+                "a4",
+            ],
+            "system": [
+                "system1",
+                "system2",
+                "system3",
+                "system4",
+                "s1",
+                "s2",
+                "s3",
+                "s4",
+            ],
+            "prompt": [
+                "prompt1",
+                "prompt2",
+                "prompt3",
+                "prompt4",
+                "p1",
+                "p2",
+                "p3",
+                "p4",
+            ],
+        }
+    )
+
+
+@pytest.fixture
+def df_short():
+    return pd.DataFrame(
+        {
+            "id": ["id1", "id2", "id3", "id4"],
+            "parent_id": ["None", "id1", "id2", "id3"],
+            "answer": ["answer1", "answer2", "answer3", "answer4"],
+            "system": ["system1", "system2", "system3", "system4"],
+            "prompt": ["prompt1", "prompt2", "prompt3", "prompt4"],
+        }
+    )
+
+
+@pytest.fixture
+def cfg():
+    cfg = MagicMock()
+    cfg.dataset.parent_id_column = "parent_id"
+    cfg.dataset.system_column = "system"
+    cfg.dataset.prompt_column = "prompt"
+    cfg.dataset.answer_column = "answer"
+    cfg.dataset.limit_chained_samples = True
+    return cfg
+
+
+def test_conversation_chain_handler(cfg, df):
+    handler = ConversationChainHandler(df, cfg)
+
+    assert len(handler) == 2, len(handler)
+
+    data = handler[0]
+    assert data == {
+        "prompts": ["prompt1", "prompt2", "prompt3", "prompt4"],
+        "answers": ["answer1", "answer2", "answer3", "answer4"],
+        "systems": ["system1", "system2", "system3", "system4"],
+    }
+
+    data = handler[1]
+    assert data == {
+        "prompts": ["p1", "p2", "p3", "p4"],
+        "answers": ["a1", "a2", "a3", "a4"],
+        "systems": ["s1", "s2", "s3", "s4"],
+    }
+
+
+def test_chained_samples_disabled(df_short, cfg):
+    cfg.dataset.limit_chained_samples = False
+    cfg.dataset.parent_id_column = "None"
+
+    handler = ConversationChainHandler(df_short, cfg)
+    assert len(handler) == 4
+    for i in range(4):
+        assert handler[i] == {
+            "prompts": [f"prompt{i+1}"],
+            "answers": [f"answer{i+1}"],
+            "systems": [f"system{i+1}"],
+        }
+
+
+def test_incomplete_chained_samples(cfg, df_short):
+    cfg.dataset.parent_id_column = "parent_id"
+    cfg.dataset.limit_chained_samples = False
+
+    handler = ConversationChainHandler(df_short, cfg)
+    assert handler.conversation_ids_lists == [[0], [0, 1], [0, 1, 2], [0, 1, 2, 3]]
+    assert len(handler) == 4
+    for i in range(4):
+        assert handler[i] == {
+            "prompts": [f"prompt{j+1}" for j in range(i + 1)],
+            "answers": [f"answer{j+1}" for j in range(i + 1)],
+            "systems": [f"system{j+1}" for j in range(i + 1)],
+        }
+
+
+def test_get_conversation_ids():
+    # test the get_conversation_ids method - normal case
+    conv_ids = ConversationChainHandler.get_conversation_ids(
+        {"id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
+    )
+    assert conv_ids == ["id1", "id2", "id3", "id4"]
+
+    # test the get_conversation_ids method - circular case, should raise ValueError
+    with pytest.raises(ValueError):
+        ConversationChainHandler.get_conversation_ids(
+            {"id1": "id4", "id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
+        )

--- a/tests/datasets/test_conversation_chain_handler.py
+++ b/tests/datasets/test_conversation_chain_handler.py
@@ -152,8 +152,8 @@ def df_with_nan():
                 "x1",
                 1,
                 2,
-                3,
-                4,
+                3.0,
+                4.0,
                 "a2",
                 "a3",
                 "a4",
@@ -166,8 +166,8 @@ def df_with_nan():
                 "x1",  # valid
                 1.0,  # valid, needs to map to the int value
                 2.0,  # valid, needs to map to the int value
-                3.0,  # valid, needs to map to the int value
-                4.0,  # valid, needs to map to the int value
+                3,  # valid, needs to map to the float value
+                4,  # valid, needs to map to the float value
                 float("nan"),  # should be ignored
                 "None",  # should be ignored
                 None,  # should be ignored

--- a/tests/datasets/test_conversation_chain_handler.py
+++ b/tests/datasets/test_conversation_chain_handler.py
@@ -120,14 +120,14 @@ def test_incomplete_chained_samples(cfg, df_short):
 
 def test_get_conversation_ids():
     # test the get_conversation_ids method - normal case
-    conv_ids = ConversationChainHandler.get_conversation_ids(
+    conv_ids = ConversationChainHandler.get_single_conversation_ids(
         {"id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
     )
     assert conv_ids == ["id1", "id2", "id3", "id4"]
 
     # test the get_conversation_ids method - circular case, should raise ValueError
     with pytest.raises(ValueError):
-        ConversationChainHandler.get_conversation_ids(
+        ConversationChainHandler.get_single_conversation_ids(
             {"id1": "id4", "id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
         )
 

--- a/tests/datasets/test_conversation_chain_handler.py
+++ b/tests/datasets/test_conversation_chain_handler.py
@@ -3,9 +3,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 import pytest
 
-from llm_studio.src.datasets.text_causal_language_modeling_ds import (
-    ConversationChainHandler,
-)
+from llm_studio.src.datasets.conversation_chain_handler import ConversationChainHandler
 
 
 @pytest.fixture

--- a/tests/datasets/test_conversation_chain_handler.py
+++ b/tests/datasets/test_conversation_chain_handler.py
@@ -120,14 +120,14 @@ def test_incomplete_chained_samples(cfg, df_short):
 
 def test_get_conversation_ids():
     # test the get_conversation_ids method - normal case
-    conv_ids = ConversationChainHandler.compute_conversation_history_ids(
+    conv_ids = ConversationChainHandler.get_conversation_ids(
         {"id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
     )
     assert conv_ids == ["id1", "id2", "id3", "id4"]
 
     # test the get_conversation_ids method - circular case, should raise ValueError
     with pytest.raises(ValueError):
-        ConversationChainHandler.compute_conversation_history_ids(
+        ConversationChainHandler.get_conversation_ids(
             {"id1": "id4", "id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
         )
 

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -30,9 +30,9 @@ def test_clean_output():
     cfg = mock.MagicMock()
     cfg.tokenizer._stop_words = ["<stop>", "<stop2>", "<stop3>"]
 
-    predicted_text_clean = CustomDataset.clean_output(
-        output=output, prompts=None, cfg=cfg
-    )["predicted_text"]
+    predicted_text_clean = CustomDataset.clean_output(output=output, cfg=cfg)[
+        "predicted_text"
+    ]
     assert predicted_text_clean == [
         "This is a test",
         "This is a test",
@@ -123,8 +123,6 @@ def test_init(mock_auto_tokenizer):
 
     assert dataset.df.equals(df)
     assert dataset.mode == "train"
-    assert all(dataset.indices == np.array([0, 1, 2]))
-    assert dataset.answers == ["4", "5", "6"]
 
 
 def test_get_parent_ids(mock_auto_tokenizer):

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -218,3 +218,9 @@ def test_getitem():
 
     assert result["input_ids"].shape == (513,)
     assert result["prompt_input_ids"].shape == (513,)
+
+
+    dataset.get_chained_prompt_text_list(0)
+
+
+

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -162,17 +162,15 @@ def test_getitem():
 
     result = dataset[0]
     assert isinstance(result, dict)
-    assert set(result.keys()) == set(
-        [
-            "labels",
-            "input_ids",
-            "attention_mask",
-            "prompt_input_ids",
-            "prompt_attention_mask",
-            "answer_input_ids",
-            "answer_attention_mask",
-        ]
-    )
+    assert set(result.keys()) == {
+        "labels",
+        "input_ids",
+        "attention_mask",
+        "prompt_input_ids",
+        "prompt_attention_mask",
+        "answer_input_ids",
+        "answer_attention_mask",
+    }
 
     dataset.tokenizer.convert_ids_to_tokens(result["input_ids"])
 
@@ -219,8 +217,10 @@ def test_getitem():
     assert result["input_ids"].shape == (513,)
     assert result["prompt_input_ids"].shape == (513,)
 
-
-    dataset.get_chained_prompt_text_list(0)
-
-
-
+    assert dataset.get_chained_prompt_text_list(0) == [
+        "system 1prompt 1",
+        "answer 1",
+        "prompt 2",
+        "answer 2",
+        "prompt 3",
+    ]

--- a/tests/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/datasets/test_text_causal_language_modeling_ds.py
@@ -10,7 +10,11 @@ from llm_studio.python_configs.text_causal_language_modeling_config import (
     ConfigNLPCausalLMTokenizer,
     ConfigProblemBase,
 )
-from llm_studio.src.datasets.text_causal_language_modeling_ds import CustomDataset
+from llm_studio.src.datasets.text_causal_language_modeling_ds import (
+    CustomDataset,
+    ConversationChainHandlerConfig,
+    ConversationChainHandler,
+)
 
 
 def test_clean_output():
@@ -266,3 +270,168 @@ def test_getitem():
 
     assert result["input_ids"].shape == (513,)
     assert result["prompt_input_ids"].shape == (513,)
+
+
+def test_conversation_chain_handler():
+    # create some mock data
+    df = pd.DataFrame(
+        {
+            "id": ["id1", "id2", "id3", "id4"],
+            "parent_id": ["None", "id1", "id2", "id3"],
+            "answer": ["answer1", "answer2", "answer3", "answer4"],
+            "system": ["system1", "system2", "system3", "system4"],
+            "prompt": ["prompt1", "prompt2", "prompt3", "prompt4"],
+        }
+    )
+
+    # Create a ConversationChainHandlerConfig
+    conversation_chain_cfg = ConversationChainHandlerConfig(
+        parent_id_column="parent_id",
+        system_column="system",
+        prompt_column="prompt",
+        answer_column="answer",
+        limit_chained_samples=False,
+    )
+
+    # create an instance of the ConversationChainHandler with the mock data and config
+    handler = ConversationChainHandler(df, conversation_chain_cfg)
+
+    # test the __len__ method
+    assert len(handler) == 4
+
+    # test the __getitem__ method
+    data = handler[0]
+    assert data == {
+        "prompts": ["prompt1"],
+        "answers": ["answer1"],
+        "systems": ["system1"],
+    }
+
+    # test the get_conversation_ids method - normal case
+    conv_ids = handler.get_conversation_ids(
+        {"id2": "id1", "id3": "id2", "id4": "id3", "id1": "None"}, "id4"
+    )
+    assert conv_ids == ["id4", "id3", "id2", "id1"]
+
+    # test the get_conversation_ids method - circular case, should raise ValueError
+    with pytest.raises(ValueError):
+        handler.get_conversation_ids(
+            {"id1": "id4", "id2": "id1", "id3": "id2", "id4": "id3"}, "id4"
+        )
+
+
+def test_no_parent_column():
+    # Test case where the configuration does not include a parent_id column
+    df = pd.DataFrame(
+        {
+            "id": ["id1", "id2", "id3", "id4"],
+            "answer": ["answer1", "answer2", "answer3", "answer4"],
+            "system": ["system1", "system2", "system3", "system4"],
+            "prompt": ["prompt1", "prompt2", "prompt3", "prompt4"],
+        }
+    )
+
+    conversation_chain_cfg = ConversationChainHandlerConfig(
+        parent_id_column="None",
+        system_column="system",
+        prompt_column="prompt",
+        answer_column="answer",
+    )
+
+    handler = ConversationChainHandler(df, conversation_chain_cfg)
+
+    assert len(handler) == 4
+    assert handler[2] == {
+        "prompts": ["prompt3"],
+        "answers": ["answer3"],
+        "systems": ["system3"],
+    }
+
+
+def test_no_system_column():
+    # Test case where the configuration does not include a system column
+    df = pd.DataFrame(
+        {
+            "id": ["id1", "id2", "id3", "id4"],
+            "parent_id": ["None", "id1", "id2", "id3"],
+            "answer": ["answer1", "answer2", "answer3", "answer4"],
+            "prompt": ["prompt1", "prompt2", "prompt3", "prompt4"],
+        }
+    )
+
+    conversation_chain_cfg = ConversationChainHandlerConfig(
+        parent_id_column="parent_id",
+        system_column="None",
+        prompt_column="prompt",
+        answer_column="answer",
+    )
+
+    handler = ConversationChainHandler(df, conversation_chain_cfg)
+
+    assert handler[3]["systems"] == [""]
+
+
+def test_limit_chained_samples():
+    # Test case where limit_chained_samples is enabled
+    df = pd.DataFrame(
+        {
+            "id": ["id1", "id2", "id3", "id4"],
+            "parent_id": ["None", "id1", "id2", "id3"],
+            "answer": ["answer1", "answer2", "answer3", "answer4"],
+            "system": ["system1", "system2", "system3", "system4"],
+            "prompt": ["prompt1", "prompt2", "prompt3", "prompt4"],
+        }
+    )
+
+    conversation_chain_cfg = ConversationChainHandlerConfig(
+        parent_id_column="parent_id",
+        system_column="system",
+        prompt_column="prompt",
+        answer_column="answer",
+        limit_chained_samples=True,
+    )
+
+    handler = ConversationChainHandler(df, conversation_chain_cfg)
+
+    assert handler[0] == {
+        "prompts": ["prompt1"],
+        "answers": ["answer1"],
+        "systems": ["system1"],
+    }
+
+
+def test_no_answer_column():
+    # Test case where the answer column does not exist in dataframe. It should default to empty string
+    df = pd.DataFrame(
+        {
+            "id": ["id1", "id2", "id3", "id4"],
+            "parent_id": ["None", "id1", "id2", "id3"],
+            "system": ["system1", "system2", "system3", "system4"],
+            "prompt": ["prompt1", "prompt2", "prompt3", "prompt4"],
+        }
+    )
+
+    conversation_chain_cfg = ConversationChainHandlerConfig(
+        parent_id_column="parent_id",
+        system_column="system",
+        prompt_column="prompt",
+        answer_column="non_existent",
+    )
+
+    handler = ConversationChainHandler(df, conversation_chain_cfg)
+
+    assert handler[0]["answers"] == [""]
+
+
+def test_empty_dataframe():
+    # Test case where input dataframe is empty
+    df = pd.DataFrame()
+
+    conversation_chain_cfg = ConversationChainHandlerConfig(
+        system_column="system",
+        prompt_column="prompt",
+        answer_column="answer",
+    )
+
+    handler = ConversationChainHandler(df, conversation_chain_cfg)
+    assert len(handler) == 0


### PR DESCRIPTION
This PR refactors the logic for conversation chaining into a separate class.

In addition, the dataset class is slightly refactored:
- `init` does not check for missing values etc., this is moved to sanity check method
- `encodings` list is split into `prompt_encodings` and `answer_encodings` for better readability
- `get_input_columns` was removed to make the class slimmer.

I have not changed any of the logic to include Llama2-chat prompting style. Maybe we can create a separate PR for this?

Fixes #370