### PR TITLE
Fix conversation chain format output

### DIFF
--- a/llm_studio/src/datasets/conversation_chain_handler.py
+++ b/llm_studio/src/datasets/conversation_chain_handler.py
@@ -190,7 +190,7 @@ class ConversationChainHandler:
             "systems": systems,
         }
 
-    def get_end_conversation_ids(self):
+    def get_conversation_end_ids(self):
         """
         Gets the end conversation IDs for each conversation chain.
         """

--- a/llm_studio/src/datasets/conversation_chain_handler.py
+++ b/llm_studio/src/datasets/conversation_chain_handler.py
@@ -190,6 +190,14 @@ class ConversationChainHandler:
             "systems": systems,
         }
 
+    def get_end_conversation_ids(self):
+        """
+        Gets the end conversation IDs for each conversation chain.
+        """
+        return [
+            conversation_chain[-1] for conversation_chain in self.conversation_chain_ids
+        ]
+
 
 def get_conversation_chains(
     df, cfg, limit_chained_samples=True

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -292,13 +292,13 @@ class CustomDataset(Dataset):
 
         # in case limit_chained_samples is True, only last answer is predicted
         end_conversation_ids = (
-            self.conversation_chain_handler.get_end_conversation_ids()
+            self.conversation_chain_handler.get_conversation_end_ids()
         )
 
         if "predicted_text" in output.keys():
             output["predicted_text"] = np.array(output["predicted_text"])
 
-        self.conversation_chain_handler.get_end_conversation_ids()
+        self.conversation_chain_handler.get_conversation_end_ids()
 
         if isinstance(cfg.dataset.prompt_column, tuple):
             for col in cfg.dataset.prompt_column:

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -300,7 +300,17 @@ class CustomDataset(Dataset):
             output[cfg.dataset.prompt_column] = df[cfg.dataset.prompt_column].values
 
         if "predicted_text" in output.keys():
-            df[f"pred_{cfg.dataset.answer_column}"] = output["predicted_text"]
+            # in case limit_chained_samples is True, only last answer is predicted
+            end_conversation_ids = (
+                self.conversation_chain_handler.get_end_conversation_ids()
+            )
+            df[f"pred_{cfg.dataset.answer_column}"] = (
+                "NO ANSWER GENERATED. "
+                "ONLY LAST ANSWER OF A CONVERSATION IS PREDICTED."
+            )
+            df.iloc[end_conversation_ids, f"pred_{cfg.dataset.answer_column}"] = output[
+                "predicted_text"
+            ]
 
         return output, df
 

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -290,20 +290,25 @@ class CustomDataset(Dataset):
 
         output.pop("target_text", None)
 
+        # in case limit_chained_samples is True, only last answer is predicted
+        end_conversation_ids = (
+            self.conversation_chain_handler.get_end_conversation_ids()
+        )
+
         if "predicted_text" in output.keys():
             output["predicted_text"] = np.array(output["predicted_text"])
 
+        self.conversation_chain_handler.get_end_conversation_ids()
+
         if isinstance(cfg.dataset.prompt_column, tuple):
             for col in cfg.dataset.prompt_column:
-                output[col] = df[col].values
+                output[col] = df.loc[end_conversation_ids, col].values
         else:
-            output[cfg.dataset.prompt_column] = df[cfg.dataset.prompt_column].values
+            output[cfg.dataset.prompt_column] = df.loc[
+                end_conversation_ids, cfg.dataset.prompt_column
+            ].values
 
         if "predicted_text" in output.keys():
-            # in case limit_chained_samples is True, only last answer is predicted
-            end_conversation_ids = (
-                self.conversation_chain_handler.get_end_conversation_ids()
-            )
             df[f"pred_{cfg.dataset.answer_column}"] = (
                 "NO ANSWER GENERATED. "
                 "ONLY LAST ANSWER OF A CONVERSATION IS PREDICTED."

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -308,10 +308,9 @@ class CustomDataset(Dataset):
                 "NO ANSWER GENERATED. "
                 "ONLY LAST ANSWER OF A CONVERSATION IS PREDICTED."
             )
-            df.iloc[end_conversation_ids, f"pred_{cfg.dataset.answer_column}"] = output[
+            df.loc[end_conversation_ids, f"pred_{cfg.dataset.answer_column}"] = output[
                 "predicted_text"
             ]
-
         return output, df
 
     @classmethod

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -298,8 +298,6 @@ class CustomDataset(Dataset):
         if "predicted_text" in output.keys():
             output["predicted_text"] = np.array(output["predicted_text"])
 
-        self.conversation_chain_handler.get_conversation_end_ids()
-
         if isinstance(cfg.dataset.prompt_column, tuple):
             for col in cfg.dataset.prompt_column:
                 output[col] = df.loc[end_conversation_ids, col].values


### PR DESCRIPTION
This PR fixes the size mismatch between `len(df) `and `len(predicted_answers)` when `limit_chained_samples=True`.

Fixes #430 