### PR TITLE
Cast missing env variables to String

### DIFF
--- a/llm_studio/app_utils/setting_utils.py
+++ b/llm_studio/app_utils/setting_utils.py
@@ -281,7 +281,7 @@ def _load_secrets(q: Q):
     secret_name, secrets_handler = _get_secrets_handler(q)
     for key in SECRET_KEYS:
         try:
-            q.client[key] = secrets_handler.load(key) or ""
+            q.client[key] = secrets_handler.load(key) or default_cfg.user_settings[key]
         except Exception:
             logger.error(f"Could not load password {key} from {secret_name}")
             q.client[key] = ""

--- a/llm_studio/app_utils/setting_utils.py
+++ b/llm_studio/app_utils/setting_utils.py
@@ -76,8 +76,8 @@ class NoSaver:
     def save(self, name: str, password: str):
         pass
 
-    def load(self, name: str):
-        pass
+    def load(self, name: str) -> str:
+        return ""
 
     def delete(self, name: str):
         pass
@@ -96,12 +96,12 @@ class KeyRingSaver(NoSaver):
     def save(self, name: str, password: str):
         keyring.set_password(self.namespace, name, password)
 
-    def load(self, name: str):
-        return keyring.get_password(self.namespace, name)
+    def load(self, name: str) -> str:
+        return keyring.get_password(self.namespace, name) or ""  # type: ignore
 
     def delete(self, name: str):
         try:
-            keyring.delete_password(self.namespace, name) or ""
+            keyring.delete_password(self.namespace, name)
         except (KeyringLocked, PasswordDeleteError):
             pass
         except Exception as e:

--- a/llm_studio/app_utils/setting_utils.py
+++ b/llm_studio/app_utils/setting_utils.py
@@ -101,7 +101,7 @@ class KeyRingSaver(NoSaver):
 
     def delete(self, name: str):
         try:
-            keyring.delete_password(self.namespace, name)
+            keyring.delete_password(self.namespace, name) or ""
         except (KeyringLocked, PasswordDeleteError):
             pass
         except Exception as e:
@@ -128,13 +128,13 @@ class EnvFileSaver(NoSaver):
         with open(self.filename, "w") as f:
             yaml.safe_dump(data, f)
 
-    def load(self, name: str):
+    def load(self, name: str) -> str:
         if not os.path.exists(self.filename):
-            return None
+            return ""
 
         with open(self.filename, "r") as f:
             data = yaml.safe_load(f)
-            return data.get(name, None)
+            return data.get(name, "")
 
     def delete(self, name: str):
         if os.path.exists(self.filename):
@@ -281,7 +281,7 @@ def _load_secrets(q: Q):
     secret_name, secrets_handler = _get_secrets_handler(q)
     for key in SECRET_KEYS:
         try:
-            q.client[key] = secrets_handler.load(key)
+            q.client[key] = secrets_handler.load(key) or ""
         except Exception:
             logger.error(f"Could not load password {key} from {secret_name}")
             q.client[key] = ""

--- a/llm_studio/app_utils/utils.py
+++ b/llm_studio/app_utils/utils.py
@@ -1719,6 +1719,9 @@ def start_experiment(cfg: Any, q: Q, pre: str, gpu_list: Optional[List] = None) 
         env_vars.update(
             {"HUGGINGFACE_TOKEN": q.client["default_huggingface_api_token"]}
         )
+
+    env_vars = {k: v or "" for k, v in env_vars.items()}
+
     cfg = copy_config(cfg, q)
     cfg.output_directory = f"{get_output_dir(q)}/{cfg.experiment_name}/"
     os.makedirs(cfg.output_directory)


### PR DESCRIPTION
Potential hotfix for #435 

So far, I wasn't able to reproduce the issue. Given the error message `TypeError: expected str, bytes or os.PathLike object, not NoneType`, I suspect `env_vars` contain some `None` variables.

I will investigate the issue further, and potentially check with @RobMulla who also encountered it.