### PR TITLE
Fix empty answers datasets

### DIFF
--- a/llm_studio/src/metrics/text_causal_language_modeling_metrics.py
+++ b/llm_studio/src/metrics/text_causal_language_modeling_metrics.py
@@ -28,7 +28,11 @@ def sacrebleu_score(
     for predicted_text, target_text in zip(
         results["predicted_text"], results["target_text"]
     ):
-        scores.append(metric.sentence_score(predicted_text, [target_text]).score)
+        if target_text == "":
+            score = 0.0
+        else:
+            score = metric.sentence_score(predicted_text, [target_text]).score
+        scores.append(score)
     return np.array(scores)
 
 

--- a/llm_studio/src/plots/text_causal_language_modeling_plots.py
+++ b/llm_studio/src/plots/text_causal_language_modeling_plots.py
@@ -114,7 +114,7 @@ class Plots:
         # Limit to max 15 prompt-conversation-answer rounds
         # This yields to max 5 * sum_{i=1}^{15} i = 600 rows in the DataFrame
         max_conversation_length = min(
-            max([len(conversation["prompts"]) for conversation in conversations] + [1]),
+            max([len(conversation["prompts"]) for conversation in conversations]),
             15,
         )
 

--- a/llm_studio/src/plots/text_causal_language_modeling_plots.py
+++ b/llm_studio/src/plots/text_causal_language_modeling_plots.py
@@ -114,8 +114,7 @@ class Plots:
         # Limit to max 15 prompt-conversation-answer rounds
         # This yields to max 5 * sum_{i=1}^{15} i = 600 rows in the DataFrame
         max_conversation_length = min(
-            max([len(conversation["prompts"]) for conversation in conversations]),
-            15,
+            max([len(conversation["prompts"]) for conversation in conversations]), 15
         )
 
         conversations_to_display = []

--- a/llm_studio/src/plots/text_causal_language_modeling_plots.py
+++ b/llm_studio/src/plots/text_causal_language_modeling_plots.py
@@ -114,7 +114,8 @@ class Plots:
         # Limit to max 15 prompt-conversation-answer rounds
         # This yields to max 5 * sum_{i=1}^{15} i = 600 rows in the DataFrame
         max_conversation_length = min(
-            max([len(conversation["prompts"]) for conversation in conversations]), 15
+            max([len(conversation["prompts"]) for conversation in conversations] + [1]),
+            15,
         )
 
         conversations_to_display = []


### PR DESCRIPTION
This PR

- Does not drop rows where the answer column is missing. Rows where the prompt column is empty will still be dropped.
- Ensures that train/val Dataframe are not empty.

Fixes  #451
Fixes #452 