### PR TITLE
enforce strict mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,7 @@ style: reports pipenv
 	-$(PIPENV) run flake8 | tee -a reports/flake8_errors.log
 	@if [ -s reports/flake8_errors.log ]; then exit 1; fi
 
-	-$(PIPENV) run mypy . --check-untyped-defs | tee -a reports/mypy.log || echo "mypy failed" >> reports/mypy_errors.log
-	@if [ -s reports/mypy_errors.log ]; then exit 1; fi
+	-$(PIPENV) run mypy . --check-untyped-defs | tee -a reports/mypy.log
 	@if ! grep -Eq "Success: no issues found in [0-9]+ source files" reports/mypy.log ; then exit 1; fi
 
 .PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ style: reports pipenv
 
 	-$(PIPENV) run mypy . --check-untyped-defs | tee -a reports/mypy.log || echo "mypy failed" >> reports/mypy_errors.log
 	@if [ -s reports/mypy_errors.log ]; then exit 1; fi
+	@if ! grep -Eq "Success: no issues found in [0-9]+ source files" reports/mypy.log ; then exit 1; fi
 
 .PHONY: format
 format: pipenv

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -98,7 +98,7 @@ def save_checkpoint(model: torch.nn.Module, path: str, cfg: Any):
     if cfg.environment.use_deepspeed:
         if path is not None:
             # gather model params from all ranks
-            model.save_checkpoint(os.path.join(path, "ds_checkpoint"))
+            model.save_checkpoint(os.path.join(path, "ds_checkpoint"))  # type: ignore[operator] # noqa: E501
             if cfg.environment._local_rank == 0:
                 # load to cpu
                 state_dict = get_fp32_state_dict_from_zero_checkpoint(

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -98,7 +98,7 @@ def save_checkpoint(model: torch.nn.Module, path: str, cfg: Any):
     if cfg.environment.use_deepspeed:
         if path is not None:
             # gather model params from all ranks
-            model.save_checkpoint(os.path.join(path, "ds_checkpoint"))  # type: ignore[operator] # noqa: E501
+            model.save_checkpoint(os.path.join(path, "ds_checkpoint"))
             if cfg.environment._local_rank == 0:
                 # load to cpu
                 state_dict = get_fp32_state_dict_from_zero_checkpoint(


### PR DESCRIPTION
Enforce mypy checks. Fixes #464 

Note: For testing, this PR should fail initially as `# type: ignore` comment was disabled in one place.