### PR TITLE
Fix download model

### DIFF
--- a/llm_studio/app_utils/sections/experiment.py
+++ b/llm_studio/app_utils/sections/experiment.py
@@ -1622,7 +1622,8 @@ async def experiment_download_model(q: Q):
         model_save_time = time.time()
         model.backbone.save_pretrained(checkpoint_path)
         # See PreTrainedTokenizerBase.save_pretrained for documentation
-        # Safeguard against None return if tokenizer class is not inherited from PreTrainedTokenizerBase
+        # Safeguard against None return if tokenizer class is
+        # not inherited from PreTrainedTokenizerBase
         tokenizer_files = list(tokenizer.save_pretrained(checkpoint_path) or [])
 
         card = get_model_card(cfg, model, repo_id="<path_to_local_folder>")
@@ -1664,7 +1665,8 @@ async def experiment_download_model(q: Q):
             add_file_to_zip(zf=zf, path=path)
 
         # Add all files that were created after the model was saved.
-        # This is useful for potential changes/different naming conventions across different backbones.
+        # This is useful for potential changes/different
+        # naming conventions across different backbones.
         for file in os.listdir(checkpoint_path):
             file_path = os.path.join(checkpoint_path, file)
             if (
@@ -1675,7 +1677,8 @@ async def experiment_download_model(q: Q):
                 add_file_to_zip(zf=zf, path=file)
                 paths_added.append(file_path)
                 logger.info(
-                    f"Added {file_path} to zip file as it was created when saving the model state."
+                    f"Added {file_path} to zip file as it "
+                    "was created when saving the model state."
                 )
         zf.close()
 

--- a/llm_studio/app_utils/sections/experiment.py
+++ b/llm_studio/app_utils/sections/experiment.py
@@ -1644,7 +1644,10 @@ async def experiment_download_model(q: Q):
             "added_tokens.json",
             "model_card.md",
         ]
-        FILES_TO_PUSH = set(FILES_TO_PUSH + tokenizer_files)
+        FILES_TO_PUSH = set(
+            FILES_TO_PUSH
+            + [os.path.split(tokenizer_file)[-1] for tokenizer_file in tokenizer_files]
+        )
 
         # Add tokenizer and config.json files, as well as potential classification head
         paths_added = []

--- a/llm_studio/app_utils/sections/experiment.py
+++ b/llm_studio/app_utils/sections/experiment.py
@@ -1638,6 +1638,7 @@ async def experiment_download_model(q: Q, error: str = ""):
             "config.json",
             "added_tokens.json",
             "model_card.md",
+            "classification_head.pth",
         ]
 
         for file in FILES_TO_PUSH:

--- a/llm_studio/app_utils/sections/experiment.py
+++ b/llm_studio/app_utils/sections/experiment.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import os
 import shutil
+import time
 import zipfile
 from pathlib import Path
 from typing import Callable, List, Optional, Set
@@ -1591,7 +1592,7 @@ def get_experiment_list_message_bar(q):
     return msg_bar
 
 
-async def experiment_download_model(q: Q, error: str = ""):
+async def experiment_download_model(q: Q):
     experiment = q.client["experiment/display/experiment"]
     experiment_path = q.client["experiment/display/experiment_path"]
     zip_path = get_model_path(experiment.name, experiment_path)
@@ -1617,8 +1618,12 @@ async def experiment_download_model(q: Q, error: str = ""):
 
         model = unwrap_model(model)
         checkpoint_path = cfg.output_directory
+
+        model_save_time = time.time()
         model.backbone.save_pretrained(checkpoint_path)
-        tokenizer.save_pretrained(checkpoint_path)
+        # See PreTrainedTokenizerBase.save_pretrained for documentation
+        # Safeguard against None return if tokenizer class is not inherited from PreTrainedTokenizerBase
+        tokenizer_files = list(tokenizer.save_pretrained(checkpoint_path) or [])
 
         card = get_model_card(cfg, model, repo_id="<path_to_local_folder>")
         card.save(os.path.join(experiment_path, "model_card.md"))
@@ -1638,19 +1643,37 @@ async def experiment_download_model(q: Q, error: str = ""):
             "config.json",
             "added_tokens.json",
             "model_card.md",
-            "classification_head.pth",
         ]
+        FILES_TO_PUSH = set(FILES_TO_PUSH + tokenizer_files)
 
+        # Add tokenizer and config.json files, as well as potential classification head
+        paths_added = []
         for file in FILES_TO_PUSH:
             path = os.path.join(experiment_path, file)
             if os.path.isfile(path):
+                paths_added.append(path)
                 add_file_to_zip(zf=zf, path=path)
 
-        # Add model weight files
-        weight_files = glob.glob(os.path.join(checkpoint_path, "pytorch_model*.*"))
-        for file in weight_files:
-            add_file_to_zip(zf=zf, path=file)
+        # Add model weight files. save_pretrained() does not return the saved files
+        weight_paths = glob.glob(os.path.join(checkpoint_path, "pytorch_model*.*"))
+        for path in weight_paths:
+            paths_added.append(path)
+            add_file_to_zip(zf=zf, path=path)
 
+        # Add all files that were created after the model was saved.
+        # This is useful for potential changes/different naming conventions across different backbones.
+        for file in os.listdir(checkpoint_path):
+            file_path = os.path.join(checkpoint_path, file)
+            if (
+                os.path.getmtime(file_path) > model_save_time
+                and file_path not in paths_added
+                and file_path != zip_path
+            ):
+                add_file_to_zip(zf=zf, path=file)
+                paths_added.append(file_path)
+                logger.info(
+                    f"Added {file_path} to zip file as it was created when saving the model state."
+                )
         zf.close()
 
     download_url = get_download_link(q, zip_path)

--- a/llm_studio/app_utils/sections/experiment.py
+++ b/llm_studio/app_utils/sections/experiment.py
@@ -1644,6 +1644,7 @@ async def experiment_download_model(q: Q):
             "config.json",
             "added_tokens.json",
             "model_card.md",
+            "classification_head.pth",
         ]
         FILES_TO_PUSH = set(
             FILES_TO_PUSH


### PR DESCRIPTION
Make Download Model functionality robust against various model backbones/tokenizers.

- Fetch tokenizer files from `tokenizer.save_pretrained`
- Monitor experiment folder and add files that where modified after the backbone/tokenizer have been saved

Fixes #489 

