### PR TITLE
Support for Flash Attention 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ pipenv:
 .PHONY: setup
 setup: pipenv
 	$(PIPENV) install --verbose --python $(PYTHON_VERSION)
-	$(PIPENV_PIP) install flash-attn==2.3.3 --no-build-isolation
+	-$(PIPENV_PIP) install flash-attn==2.3.3 --no-build-isolation
 
 .PHONY: setup-dev
 setup-dev: pipenv

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ setup: pipenv
 .PHONY: setup-dev
 setup-dev: pipenv
 	$(PIPENV) install --verbose --dev --python $(PYTHON_VERSION)
-	$(PIPENV_PIP) install flash-attn==2.3.3 --no-build-isolation
+	- $(PIPENV_PIP) install flash-attn==2.3.3 --no-build-isolation
 
 .PHONY: setup-no-flash
 setup-no-flash: pipenv

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,16 @@ pipenv:
 .PHONY: setup
 setup: pipenv
 	$(PIPENV) install --verbose --python $(PYTHON_VERSION)
+	$(PIPENV_PIP) install flash-attn==2.3.3 --no-build-isolation
 
 .PHONY: setup-dev
 setup-dev: pipenv
 	$(PIPENV) install --verbose --dev --python $(PYTHON_VERSION)
+	$(PIPENV_PIP) install flash-attn==2.3.3 --no-build-isolation
+
+.PHONY: setup-no-flash
+setup-no-flash: pipenv
+	$(PIPENV) install --verbose --python $(PYTHON_VERSION)
 
 .PHONY: export-requirements
 export-requirements: pipenv

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ H2O LLM Studio requires a machine with Ubuntu 16.04+ and at least one recent Nvi
 
 For more information about installation prerequisites, see the [Set up H2O LLM Studio](https://docs.h2o.ai/h2o-llmstudio/get-started/set-up-llm-studio#prerequisites) guide in the documentation.
 
+For a performance comparison of different GPUs, see the [H2O LLM Studio performance](https://h2oai.github.io/h2o-llmstudio/get-started/llm-studio-performance) guide in the documentation.
+
 ### Recommended Install
 
 The recommended way to install H2O LLM Studio is using pipenv with Python 3.10. To install Python 3.10 on Ubuntu 16.04+, execute the following commands:
@@ -114,12 +116,21 @@ The following command will create a virtual environment using pipenv and will in
 make setup
 ```
 
+If you are having troubles installing the flash_attn package, consider running
+
+```bash
+make setup-no-flash
+```
+
+instead. This will install the dependencies without the flash_attn package. Note that this will disable the use of Flash Attention 2 and model training will be slower and consume more memory.
+
 ### Using requirements.txt
 
 If you wish to use conda or another virtual environment, you can also install the dependencies using the requirements.txt file:
 
 ```bash
 pip install -r requirements.txt
+pip install flash-attn==2.3.3 --no-build-isolation  # optional for Flash Attention 2
 ```
 
 ## Run H2O LLM Studio GUI

--- a/documentation/docs/guide/experiments/experiment-settings.md
+++ b/documentation/docs/guide/experiments/experiment-settings.md
@@ -29,6 +29,7 @@ import ASintermediateDropout from '../../tooltips/experiments/_intermediate-drop
 import ASpretrainedWeights from '../../tooltips/experiments/_pretrained-weights.mdx';
 import TSoptimizer from '../../tooltips/experiments/_optimizer.mdx';
 import TSlearningRate from '../../tooltips/experiments/_learning-rate.mdx';
+import TSuseflashattention2 from '../../tooltips/experiments/_use-flash-attention-2.mdx';
 import TSbatchSize from '../../tooltips/experiments/_batch-size.mdx';
 import TSepochs from '../../tooltips/experiments/_epochs.mdx';
 import TSschedule from '../../tooltips/experiments/_schedule.mdx';
@@ -230,6 +231,10 @@ The settings under each category are listed and described below.
 ### Learning rate
 
 <TSlearningRate/>
+
+### Use Flash Attention 2
+
+<TSuseflashattention2/>
 
 ### Batch size
 

--- a/documentation/docs/tooltips/experiments/_use-flash-attention-2.mdx
+++ b/documentation/docs/tooltips/experiments/_use-flash-attention-2.mdx
@@ -1,0 +1,5 @@
+If enabled, Flash Attention 2 will be used to compute the attention. Otherwise, the attention will be computed using the standard attention mechanism. 
+
+Flash Attention 2 is a new attention mechanism that is faster and more memory efficient than the standard attention mechanism. Only newer GPUs support this feature.
+
+See https://arxiv.org/abs/2205.14135 for more details.

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -137,6 +137,7 @@ class ConfigNLPCausalLMTraining(DefaultConfig):
     differential_learning_rate_layers: Tuple[str, ...] = ()
     differential_learning_rate: float = 0.00001
 
+    use_flash_attention_2: bool = False
     batch_size: int = 2
     drop_last_batch: bool = True
     epochs: int = 1

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -671,12 +671,28 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
 
     kwargs["trust_remote_code"] = cfg.environment.trust_remote_code
 
+    if cfg.training.use_flash_attention_2:
+        try:
+            import flash_attn  # noqa: F401
+
+            use_flash_attention_2 = cfg.training.use_flash_attention_2
+            logger.info("Using Flash Attention 2.")
+        except ImportError:
+            use_flash_attention_2 = False
+            logger.warning(
+                "Flash Attention 2.0 is not available. "
+                "Please consider to run 'make setup' to install it."
+            )
+    else:
+        use_flash_attention_2 = False
+
     if cfg.architecture.pretrained:
         backbone = model_class.from_pretrained(
             cfg.llm_backbone,
             revision=cfg.environment.huggingface_branch,
             config=config,
             quantization_config=quantization_config,
+            use_flash_attention_2=use_flash_attention_2,
             **kwargs,
         )
     else:


### PR DESCRIPTION
### Adds Flash Attention 2 as an option 
(default=False)

Requires the `flash_attn` package to be installed. This needs the `--no-build-isolation` flag, so it's done in the `make setup` command. If there are any issues with the installation and the package can not be imported, H2O LLM Studio will fall back to the standard pytorch attention implementation.

### With flash-attn
```
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.147.05   Driver Version: 525.147.05   CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA GeForce ...  Off  | 00000000:0A:00.0  On |                  N/A |
| 76%   62C    P2   336W / 370W |  17085MiB / 24576MiB |    100%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
```
ca. 5:00h runtime for 2048 context (no pad) otherwise default params


### Without flash-attn
```
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 525.147.05   Driver Version: 525.147.05   CUDA Version: 12.0     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  NVIDIA GeForce ...  Off  | 00000000:0A:00.0  On |                  N/A |
| 83%   70C    P2   334W / 370W |  21031MiB / 24576MiB |    100%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
```
ca. 6:45h runtime for 2048 context (no pad) otherwise default params


closes #244