### PR TITLE
Enhancing Length Consistency in LLM Outputs with Token Length Penalty Loss Functions

### DIFF
--- a/llm_studio/src/losses/text_causal_language_modeling_losses.py
+++ b/llm_studio/src/losses/text_causal_language_modeling_losses.py
@@ -1,10 +1,9 @@
 import logging
 from typing import Any, KeysView
 
-from torch import nn
-
 __all__ = ["Losses"]
-
+import torch
+import torch.nn as nn
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +24,33 @@ class TokenAveragedCrossEntropyLoss(nn.Module):
         return self.loss_fn(shift_logits, shift_labels)
 
 
+class LengthBasedTACE(nn.Module):
+    def __init__(self, cfg: Any, length_penalty_coeff: float = 0.1):
+        super().__init__()
+        self.cfg = cfg
+        self.loss_fn = nn.CrossEntropyLoss()
+        self.length_penalty_coeff = length_penalty_coeff
+
+    def forward(self, logits, labels):
+        shift_logits = logits[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+
+        shift_logits = shift_logits.view(-1, shift_logits.size(-1))
+        shift_labels = shift_labels.view(-1)
+
+        loss = self.loss_fn(shift_logits, shift_labels)
+
+        true_lengths = torch.sum(labels != 0, dim=-1).float()
+        pred_lengths = torch.sum(torch.argmax(logits, dim=-1) != 0, dim=-1).float()
+
+        length_ratio = true_lengths / (pred_lengths + 1e-8)
+
+        length_penalty = torch.pow(length_ratio, self.length_penalty_coeff)
+        normalized_loss = loss / length_penalty.mean()
+
+        return normalized_loss
+
+
 class SampleAveragedCrossEntropyLoss(nn.Module):
     def __init__(self, cfg: Any):
         super().__init__()
@@ -42,12 +68,43 @@ class SampleAveragedCrossEntropyLoss(nn.Module):
         return loss
 
 
+class LengthBasedSACE(nn.Module):
+    def __init__(self, cfg: Any, length_penalty_coeff: float = 0.1):
+        super().__init__()
+        self.cfg = cfg
+        self.loss_fn = nn.CrossEntropyLoss()
+        self.length_penalty_coeff = length_penalty_coeff
+
+    def forward(self, logits, labels):
+        shift_logits = logits[..., :-1, :].contiguous()
+        shift_labels = labels[..., 1:].contiguous()
+
+        total_loss = 0.0
+
+        for i in range(labels.shape[0]):
+            sample_logit = shift_logits[i].view(-1, shift_logits.size(-1))
+            sample_label = shift_labels[i].view(-1)
+            sample_loss = self.loss_fn(sample_logit, sample_label)
+
+            true_length = torch.sum(labels[i] != 0).float()
+            pred_length = torch.sum(torch.argmax(logits[i], dim=-1) != 0).float()
+            length_ratio = true_length / (pred_length + 1e-8)
+            length_penalty = torch.pow(length_ratio, self.length_penalty_coeff)
+
+            total_loss += sample_loss / length_penalty
+
+        average_loss = total_loss / labels.shape[0]
+        return average_loss
+
+
 class Losses:
     """Losses factory."""
 
     _losses = {
         "TokenAveragedCrossEntropy": TokenAveragedCrossEntropyLoss,
         "SampleAveragedCrossEntropy": SampleAveragedCrossEntropyLoss,
+        "LengthBasedTACE": LengthBasedTACE,
+        "LengthBasedSACE": LengthBasedSACE,
     }
 
     @classmethod


### PR DESCRIPTION
Adding support for custom loss functions aimed at improving the length consistency in responses generated by fientuned LLMs. Idea is to make the output lengths of LLMs more reflective of the token lengths observed in the training data. I did several experiments using the loss functions, and noticed very low deviation in performance of models. 

The loss functions implemented are:

LengthBasedTACE (Token Averaged Cross Entropy)
LengthBasedSACE (Sample Averaged Cross Entropy)


Sharing some of the experiments I did using these losses to make a comparison with original Cross Entropy Loss:

#### Evaluation Results:

There could be some randomness involved in eval metric, but I found consistent decrease in LLMs inference time,specially the ones which scores bad & prone to generate bad responses.

| Model            | Loss Function                         | Time Taken (min) | Eval Metric |
|------------------|---------------------------------------|------------------|-------------------|
| llama13B-Chat    | Token Avg CE Loss                     | 40.45               | 0.810            |
| llama13B-Chat    | TokenLengthPenalty Token Avg          | 38.62               | 0.802            |
| llama7B-Chat    | Token Avg CE Loss                     | 12.50               | 0.7684            |
| llama7B-Chat    | TokenLengthPenalty Token Avg          | 12.12               | 0.7484            |
| Yi-6B-Chat    | Token Avg CE Loss                     | 18.50               | 0.792             |
| Yi-6B-Chat    | TokenLengthPenalty Token Avg          | 15.44               | 0.785             |
| llama13B-Chat    | Token Avg CE Loss                     | 78.20               | 0.728             |
| llama13B-Chat    | TokenLengthPenalty Token Avg          | 76.60               | 0.744             |
|   Yi-6B-Chat  | Token Avg CE Loss                     | 24.44               | 0.712             |
| Yi-6B-Chat    | TokenLengthPenalty Token Avg          | 24.20               | 0.704             |


These functions uses a length penalty coefficient, in my experiments I found 0.1 coefficient to be most stable one, therefore I kept it as default. This should help close #537 


