### PR TITLE
rm unused file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "h2o-llmstudio",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
This file is not used by the documentation. 
correct (used) file stays in https://github.com/h2oai/h2o-llmstudio/blob/main/documentation/package-lock.json