### PR TITLE
Use generation_config.json

### DIFF
--- a/documentation/docs/tooltips/experiments/_max-time.mdx
+++ b/documentation/docs/tooltips/experiments/_max-time.mdx
@@ -1,0 +1,1 @@
+The maximum amount of time you allow the computation to run for in seconds. Generation will still finish the current pass after allocated time has been passed.

--- a/llm_studio/app_utils/hugging_face_utils.py
+++ b/llm_studio/app_utils/hugging_face_utils.py
@@ -172,7 +172,7 @@ def publish_model_to_hugging_face(
     model.backbone.generation_config.push_to_hub(
         repo_id=repo_id,
         private=True,
-        commit_message="Upload generation config"
+        commit_message="Upload generation_config.json"
     )
 
     # Storing HF attributes

--- a/llm_studio/app_utils/hugging_face_utils.py
+++ b/llm_studio/app_utils/hugging_face_utils.py
@@ -168,6 +168,13 @@ def publish_model_to_hugging_face(
         safe_serialization=safe_serialization,
     )
 
+    # push generation_config to hub
+    model.generation_config.push_to_hub(
+        repo_id=repo_id,
+        private=True,
+        commit_message="Upload generation config"
+    )
+
     # Storing HF attributes
     output_directory = cfg.output_directory
     save_hf_yaml(

--- a/llm_studio/app_utils/hugging_face_utils.py
+++ b/llm_studio/app_utils/hugging_face_utils.py
@@ -169,7 +169,7 @@ def publish_model_to_hugging_face(
     )
 
     # push generation_config to hub
-    model.generation_config.push_to_hub(
+    model.backbone.generation_config.push_to_hub(
         repo_id=repo_id,
         private=True,
         commit_message="Upload generation config"

--- a/llm_studio/app_utils/hugging_face_utils.py
+++ b/llm_studio/app_utils/hugging_face_utils.py
@@ -169,9 +169,12 @@ def publish_model_to_hugging_face(
     )
 
     # push generation_config to hub
-    model.backbone.generation_config.push_to_hub(
-        repo_id=repo_id, private=True, commit_message="Upload generation_config.json"
-    )
+    if cfg.problem_type not in NON_GENERATION_PROBLEM_TYPES:
+        model.backbone.generation_config.push_to_hub(
+            repo_id=repo_id,
+            private=True,
+            commit_message="Upload generation_config.json",
+        )
 
     # Storing HF attributes
     output_directory = cfg.output_directory

--- a/llm_studio/app_utils/hugging_face_utils.py
+++ b/llm_studio/app_utils/hugging_face_utils.py
@@ -168,14 +168,6 @@ def publish_model_to_hugging_face(
         safe_serialization=safe_serialization,
     )
 
-    # push generation_config to hub
-    if cfg.problem_type not in NON_GENERATION_PROBLEM_TYPES:
-        model.backbone.generation_config.push_to_hub(
-            repo_id=repo_id,
-            private=True,
-            commit_message="Upload generation_config.json",
-        )
-
     # Storing HF attributes
     output_directory = cfg.output_directory
     save_hf_yaml(

--- a/llm_studio/app_utils/hugging_face_utils.py
+++ b/llm_studio/app_utils/hugging_face_utils.py
@@ -170,9 +170,7 @@ def publish_model_to_hugging_face(
 
     # push generation_config to hub
     model.backbone.generation_config.push_to_hub(
-        repo_id=repo_id,
-        private=True,
-        commit_message="Upload generation_config.json"
+        repo_id=repo_id, private=True, commit_message="Upload generation_config.json"
     )
 
     # Storing HF attributes

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -292,6 +292,7 @@ class ConfigNLPCausalLMPrediction(DefaultConfig):
 
     min_length_inference: int = 2
     max_length_inference: int = 256
+    max_time: float = 120.0
     batch_size_inference: int = 0
 
     do_sample: bool = False
@@ -325,6 +326,7 @@ class ConfigNLPCausalLMPrediction(DefaultConfig):
         self._possible_values["batch_size_inference"] = (0, 512, 1)
         self._possible_values["min_length_inference"] = (0, 1024, 1)
         self._possible_values["max_length_inference"] = (1, 4096, 1)
+        self._possible_values["max_time"] = (1.0, 600.0, 1.0)
 
         self._possible_values["num_beams"] = (1, 4, 1)
         self._possible_values["temperature"] = (0, 10, 0.05)

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -842,18 +842,13 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
         backbone.generation_config.max_time = cfg.prediction.max_time
         backbone.generation_config.do_sample = cfg.prediction.do_sample
         backbone.generation_config.num_beams = cfg.prediction.num_beams
-        backbone.generation_config.temperature = (
-            cfg.prediction.temperature if cfg.prediction.do_sample else None
-        )
-        backbone.generation_config.top_k = (
-            cfg.prediction.top_k if cfg.prediction.do_sample else None
-        )
-        backbone.generation_config.top_p = (
-            cfg.prediction.top_p if cfg.prediction.do_sample else None
-        )
         backbone.generation_config.repetition_penalty = (
             cfg.prediction.repetition_penalty
         )
+        if cfg.prediction.do_sample:
+            backbone.generation_config.temperature = cfg.prediction.temperature
+            backbone.generation_config.top_k = cfg.prediction.top_k
+            backbone.generation_config.top_p = cfg.prediction.top_p
         backbone.generation_config.transformers_version = transformers.__version__
 
     return backbone, config

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -836,7 +836,7 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
     if backbone.generation_config.bos_token_id != config.bos_token_id:
         backbone.generation_config.bos_token_id = config.bos_token_id
 
-    if cfg.problem_typ not in NON_GENERATION_PROBLEM_TYPES:
+    if cfg.problem_type not in NON_GENERATION_PROBLEM_TYPES:
         backbone.generation_config.min_new_tokens = cfg.prediction.min_length_inference
         backbone.generation_config.max_new_tokens = cfg.prediction.max_length_inference
         backbone.generation_config.max_time = cfg.prediction.max_time

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -836,22 +836,25 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
     if backbone.generation_config.bos_token_id != config.bos_token_id:
         backbone.generation_config.bos_token_id = config.bos_token_id
 
-    backbone.generation_config.min_new_tokens = cfg.prediction.min_length_inference
-    backbone.generation_config.max_new_tokens = cfg.prediction.max_length_inference
-    backbone.generation_config.max_time = cfg.prediction.max_time
-    backbone.generation_config.do_sample = cfg.prediction.do_sample
-    backbone.generation_config.num_beams = cfg.prediction.num_beams
-    backbone.generation_config.temperature = (
-        cfg.prediction.temperature if cfg.prediction.do_sample else None
-    )
-    backbone.generation_config.top_k = (
-        cfg.prediction.top_k if cfg.prediction.do_sample else None
-    )
-    backbone.generation_config.top_p = (
-        cfg.prediction.top_p if cfg.prediction.do_sample else None
-    )
-    backbone.generation_config.repetition_penalty = cfg.prediction.repetition_penalty
-    backbone.generation_config.transformers_version = transformers.__version__
+    if cfg.problem_typ not in NON_GENERATION_PROBLEM_TYPES:
+        backbone.generation_config.min_new_tokens = cfg.prediction.min_length_inference
+        backbone.generation_config.max_new_tokens = cfg.prediction.max_length_inference
+        backbone.generation_config.max_time = cfg.prediction.max_time
+        backbone.generation_config.do_sample = cfg.prediction.do_sample
+        backbone.generation_config.num_beams = cfg.prediction.num_beams
+        backbone.generation_config.temperature = (
+            cfg.prediction.temperature if cfg.prediction.do_sample else None
+        )
+        backbone.generation_config.top_k = (
+            cfg.prediction.top_k if cfg.prediction.do_sample else None
+        )
+        backbone.generation_config.top_p = (
+            cfg.prediction.top_p if cfg.prediction.do_sample else None
+        )
+        backbone.generation_config.repetition_penalty = (
+            cfg.prediction.repetition_penalty
+        )
+        backbone.generation_config.transformers_version = transformers.__version__
 
     return backbone, config
 

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -10,13 +10,13 @@ import coolname
 import deepspeed
 import numpy as np
 import torch
+import transformers
 from deepspeed.runtime.dataloader import DeepSpeedDataLoader
 from deepspeed.utils.zero_to_fp32 import get_fp32_state_dict_from_zero_checkpoint
 from peft import LoraConfig, PeftModel, get_peft_model
 from torch.cuda.amp import autocast
 from torch.nn.parallel import DistributedDataParallel
 from tqdm import tqdm
-import transformers
 from transformers import (
     AutoConfig,
     AutoModel,
@@ -841,9 +841,15 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
     backbone.generation_config.max_time = cfg.prediction.max_time
     backbone.generation_config.do_sample = cfg.prediction.do_sample
     backbone.generation_config.num_beams = cfg.prediction.num_beams
-    backbone.generation_config.temperature = cfg.prediction.temperature if cfg.prediction.do_sample else None
-    backbone.generation_config.top_k = cfg.prediction.top_k if cfg.prediction.do_sample else None
-    backbone.generation_config.top_p = cfg.prediction.top_p if cfg.prediction.do_sample else None
+    backbone.generation_config.temperature = (
+        cfg.prediction.temperature if cfg.prediction.do_sample else None
+    )
+    backbone.generation_config.top_k = (
+        cfg.prediction.top_k if cfg.prediction.do_sample else None
+    )
+    backbone.generation_config.top_p = (
+        cfg.prediction.top_p if cfg.prediction.do_sample else None
+    )
     backbone.generation_config.repetition_penalty = cfg.prediction.repetition_penalty
     backbone.generation_config.transformers_version = transformers.__version__
 

--- a/model_cards/text_causal_language_modeling_model_card_template.md
+++ b/model_cards/text_causal_language_modeling_model_card_template.md
@@ -45,14 +45,16 @@ generate_text = pipeline(
     token=True,
 )
 
+# generate configuration can be modified to your needs
+# generate_text.model.generation_config.min_new_tokens = {{min_new_tokens}}
+# generate_text.model.generation_config.max_new_tokens = {{max_new_tokens}}
+# generate_text.model.generation_config.do_sample = {{do_sample}}
+# generate_text.model.generation_config.num_beams = {{num_beams}}
+# generate_text.model.generation_config.temperature = float({{temperature}})
+# generate_text.model.generation_config.repetition_penalty = float({{repetition_penalty}})
+
 res = generate_text(
     "Why is drinking water so healthy?",
-    min_new_tokens={{min_new_tokens}},
-    max_new_tokens={{max_new_tokens}},
-    do_sample={{do_sample}},
-    num_beams={{num_beams}},
-    temperature=float({{temperature}}),
-    repetition_penalty=float({{repetition_penalty}}),
     renormalize_logits=True
 )
 print(res[0]["generated_text"])
@@ -88,14 +90,16 @@ model = AutoModelForCausalLM.from_pretrained(
 )
 generate_text = H2OTextGenerationPipeline(model=model, tokenizer=tokenizer)
 
+# generate configuration can be modified to your needs
+# generate_text.model.generation_config.min_new_tokens = {{min_new_tokens}}
+# generate_text.model.generation_config.max_new_tokens = {{max_new_tokens}}
+# generate_text.model.generation_config.do_sample = {{do_sample}}
+# generate_text.model.generation_config.num_beams = {{num_beams}}
+# generate_text.model.generation_config.temperature = float({{temperature}})
+# generate_text.model.generation_config.repetition_penalty = float({{repetition_penalty}})
+
 res = generate_text(
     "Why is drinking water so healthy?",
-    min_new_tokens={{min_new_tokens}},
-    max_new_tokens={{max_new_tokens}},
-    do_sample={{do_sample}},
-    num_beams={{num_beams}},
-    temperature=float({{temperature}}),
-    repetition_penalty=float({{repetition_penalty}}),
     renormalize_logits=True
 )
 print(res[0]["generated_text"])
@@ -127,15 +131,16 @@ model.cuda().eval()
 inputs = tokenizer(prompt, return_tensors="pt", add_special_tokens=False).to("cuda")
 
 # generate configuration can be modified to your needs
+# model.generation_config.min_new_tokens = {{min_new_tokens}}
+# model.generation_config.max_new_tokens = {{max_new_tokens}}
+# model.generation_config.do_sample = {{do_sample}}
+# model.generation_config.num_beams = {{num_beams}}
+# model.generation_config.temperature = float({{temperature}})
+# model.generation_config.repetition_penalty = float({{repetition_penalty}})
+
 tokens = model.generate(
     input_ids=inputs["input_ids"],
     attention_mask=inputs["attention_mask"],
-    min_new_tokens={{min_new_tokens}},
-    max_new_tokens={{max_new_tokens}},
-    do_sample={{do_sample}},
-    num_beams={{num_beams}},
-    temperature=float({{temperature}}),
-    repetition_penalty=float({{repetition_penalty}}),
     renormalize_logits=True
 )[0]
 

--- a/tests/integration/test_causal_language_modeling_oasst_cfg.yaml
+++ b/tests/integration/test_causal_language_modeling_oasst_cfg.yaml
@@ -54,6 +54,7 @@ prediction:
     batch_size_inference: 0
     do_sample: false
     max_length_inference: 256
+    max_time: 120.0
     metric: Perplexity
     metric_gpt_model: gpt-3.5-turbo-0301
     metric_gpt_template: general

--- a/tests/integration/test_causal_language_modeling_oasst_cpu_cfg.yaml
+++ b/tests/integration/test_causal_language_modeling_oasst_cpu_cfg.yaml
@@ -54,6 +54,7 @@ prediction:
   batch_size_inference: 0
   do_sample: false
   max_length_inference: 16
+  max_time: 120.0
   metric: BLEU
   metric_gpt_model: gpt-3.5-turbo-0301
   metric_gpt_template: general

--- a/tests/integration/test_sequence_to_sequence_modeling_oasst_cfg.yaml
+++ b/tests/integration/test_sequence_to_sequence_modeling_oasst_cfg.yaml
@@ -54,6 +54,7 @@ prediction:
     batch_size_inference: 0
     do_sample: false
     max_length_inference: 256
+    max_time: 120.0
     metric: Perplexity
     metric_gpt_model: gpt-3.5-turbo-0301
     metric_gpt_template: general

--- a/tests/integration/test_sequence_to_sequence_modeling_oasst_cpu_cfg.yaml
+++ b/tests/integration/test_sequence_to_sequence_modeling_oasst_cpu_cfg.yaml
@@ -54,6 +54,7 @@ prediction:
     batch_size_inference: 0
     do_sample: false
     max_length_inference: 16
+    max_time: 120.0
     metric: Perplexity
     metric_gpt_model: gpt-3.5-turbo-0301
     metric_gpt_template: general

--- a/tests/src/test_data/cfg.yaml
+++ b/tests/src/test_data/cfg.yaml
@@ -42,6 +42,7 @@ prediction:
     batch_size_inference: 0
     do_sample: false
     max_length_inference: 256
+    max_time: 120.0
     metric: GPT3.5
     min_length_inference: 2
     num_beams: 2


### PR DESCRIPTION
close #566 
close #568 

### Check1

train->valid: output1
train->valid->Wave UI chat: output1.1
pull from HF->valid: output2
pull from HF->pipeline generation: output2.1
pull from HF->Wave UI chat: output2.2

I have output1.1 == output2 == output2.1 == output2.2 but slightly different from output1 when `do_sample=False`

### Check2

```
from transformers import pipeline

generate_text = pipeline(
    model="haqishen/genconf-test",
    torch_dtype="auto",
    trust_remote_code=True,
    use_fast=True,
    device_map={"": "cuda:2"},
    token=True,
)

res = generate_text(
    input_text,
    # min_new_tokens=2,
    # max_new_tokens=256,
    # do_sample=False,
    # num_beams=1,
    # temperature=float(0.0),
    # repetition_penalty=float(1.0),
    # renormalize_logits=True
)
print(res[0]["generated_text"])
```

In this segment of code from model card, whether these parameters are commented out or not, the output remains the same.


### Check3

`generate_text.model.generation_config` outputs:

```
GenerationConfig {
  "bos_token_id": 1,
  "eos_token_id": 2,
  "max_new_tokens": 256,
  "max_time": 120.0,
  "min_new_tokens": 2,
  "pad_token_id": 0,
  "temperature": null,
  "top_k": null,
  "top_p": null
}
```

shows that the generation_config.json is automatically loaded when creating pipeline.

### Check4

Both DDP and Deepspeed works well with generation_config.json