### PR TITLE
allow lower LR in spinbox

### DIFF
--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -165,7 +165,7 @@ class ConfigNLPCausalLMTraining(DefaultConfig):
         self._possible_values["optimizer"] = Optimizers.names()
 
         self._possible_values["learning_rate"] = possible_values.Number(
-            step=0.000001, min=0.000001
+            step=1e-9, min=1e-9
         )
         self._possible_values["differential_learning_rate_layers"] = (
             possible_values.String(


### PR DESCRIPTION
allows to use learning rates down to 1-e9

![image](https://github.com/h2oai/h2o-llmstudio/assets/1069138/8a94dbd5-c298-4d3d-9412-73aebbff746e)

[Demo Video](https://github.com/h2oai/h2o-llmstudio/assets/1069138/58ec931a-160b-45f0-b4d5-0a5cf5d8bf7f)


UX is not ideal, as the notation changes between scientific e notation and decimal notation, but it should get the job done. Users need to know that the magnitude can not be changed by modifying the exponent but rather by adding a leading digit (see demo video).

closes #661 