### PR TITLE
Save checkpoint options

### DIFF
--- a/documentation/docs/get-started/llm-studio-performance.md
+++ b/documentation/docs/get-started/llm-studio-performance.md
@@ -160,7 +160,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/documentation/docs/get-started/llm-studio-performance.md
+++ b/documentation/docs/get-started/llm-studio-performance.md
@@ -160,7 +160,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/documentation/docs/tooltips/experiments/_save-best-checkpoint.mdx
+++ b/documentation/docs/tooltips/experiments/_save-best-checkpoint.mdx
@@ -1,5 +1,0 @@
-Determines if H2O LLM Studio should save the model weights of the epoch exhibiting the best validation metric. When turned **On**, H2O LLM Studio saves the model weights for the epoch exhibiting the best validation metric. When turned **Off**, H2O LLM Studio saves the model weights after the last epoch is executed.
-
-- This setting should be turned **On** with care as it has the potential to lead to overfitting of the validation data. 
-- The default goal should be to attempt to tune models so that the last or very last epoch is the best epoch.  
-- Suppose an evident decline for later epochs is observed in logging. In that case, it is usually better to adjust hyperparameters, such as reducing the number of epochs or increasing regularization, instead of turning this setting **On**.

--- a/documentation/docs/tooltips/experiments/_save-checkpoint.mdx
+++ b/documentation/docs/tooltips/experiments/_save-checkpoint.mdx
@@ -4,7 +4,7 @@ When set to **Last** it will always save the last checkpoint, this is the recomm
 
 When set to **Best** it saves the model weights for the epoch exhibiting the best validation metric.
 - This setting should be turned on with care as it has the potential to lead to overfitting of the validation data. 
-- The default goal should be to attempt to tune models so that the last or very last epoch is the best epoch.  
+- The default goal should be to attempt to tune models so that the last epoch is the best epoch.  
 - Suppose an evident decline for later epochs is observed in logging. In that case, it is usually better to adjust hyperparameters, such as reducing the number of epochs or increasing regularization, instead of turning this setting on.
 
 When set to **Disable** it will not save the checkpoint at all. This can be useful for debugging and experimenting in order to save disk space, but will disable certain functionalities like chatting or pushing to HF.

--- a/documentation/docs/tooltips/experiments/_save-checkpoint.mdx
+++ b/documentation/docs/tooltips/experiments/_save-checkpoint.mdx
@@ -1,0 +1,10 @@
+Specifies how H2O LLM Studio should save the model checkpoints.
+
+When set to **Last** it will always save the last checkpoint, this is the recommended setting.
+
+When set to **Best** it saves the model weights for the epoch exhibiting the best validation metric.
+- This setting should be turned on with care as it has the potential to lead to overfitting of the validation data. 
+- The default goal should be to attempt to tune models so that the last or very last epoch is the best epoch.  
+- Suppose an evident decline for later epochs is observed in logging. In that case, it is usually better to adjust hyperparameters, such as reducing the number of epochs or increasing regularization, instead of turning this setting on.
+
+When set to **Disable** it will not save the checkpoint at all. This can be useful for debugging and experimenting in order to save disk space, but will disable certain functionalities like chatting or pushing to HF.

--- a/documentation/docs/tooltips/experiments/_train-validation-data.mdx
+++ b/documentation/docs/tooltips/experiments/_train-validation-data.mdx
@@ -4,5 +4,4 @@ Defines whether the model should use the entire train and validation dataset dur
 - H2O LLM Studio uses both datasets for model training if you provide a train and validation dataset.
     - To define a training dataset, use the **Train dataframe** setting.
     - To define a validation dataset, use the **Validation dataframe** setting.
-- The **Train validation data** setting is only available if you turned the **Save best checkpoint** setting **Off**.
 - Turning **On** the **Train validation data** setting should produce a model that you can expect to perform better because H2O LLM Studio trained the model on more data. Though, also note that using the entire train dataset and validation dataset generally causes the model's accuracy to be *overstated* as information from the validation data is incorporated into the model during the training process.

--- a/examples/example_oasst2.yaml
+++ b/examples/example_oasst2.yaml
@@ -92,7 +92,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/examples/example_oasst2.yaml
+++ b/examples/example_oasst2.yaml
@@ -92,7 +92,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/llm_studio/app_utils/config.py
+++ b/llm_studio/app_utils/config.py
@@ -20,7 +20,7 @@ def get_size(x):
         return 2**31
 
 
-version = "1.5.0"
+version = "1.6.0-dev"
 
 try:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/llm_studio/app_utils/sections/experiment.py
+++ b/llm_studio/app_utils/sections/experiment.py
@@ -903,6 +903,9 @@ async def experiment_display(q: Q) -> None:
 
     q.client["experiment/display/experiment_path"] = experiment.path
 
+    checkpoints_exists = os.path.exists(
+        os.path.join(q.client["experiment/display/experiment_path"], "checkpoint.pth")
+    )
     status, _ = get_experiment_status(experiment.path)
 
     charts = load_charts(q.client["experiment/display/experiment_path"])
@@ -973,7 +976,7 @@ async def experiment_display(q: Q) -> None:
         ui.tab(name="experiment/display/config", label="Config"),
     ]
 
-    if status == "finished":
+    if status == "finished" and checkpoints_exists:
         tabs += [ui.tab(name="experiment/display/chat", label="Chat")]
 
     q.page["experiment/display/tab"] = ui.tab_card(
@@ -1019,22 +1022,26 @@ async def experiment_display(q: Q) -> None:
                 primary=False,
                 disabled=False,
                 tooltip=None,
-            ),
-            ui.button(
-                name="experiment/display/download_model",
-                label="Download model",
-                primary=False,
-                disabled=False,
-                tooltip=None,
-            ),
-            ui.button(
-                name="experiment/display/push_to_huggingface",
-                label="Push checkpoint to huggingface",
-                primary=False,
-                disabled=False,
-                tooltip=None,
-            ),
+            )
         ]
+
+        if checkpoints_exists:
+            buttons += [
+                ui.button(
+                    name="experiment/display/download_model",
+                    label="Download model",
+                    primary=False,
+                    disabled=False,
+                    tooltip=None,
+                ),
+                ui.button(
+                    name="experiment/display/push_to_huggingface",
+                    label="Push checkpoint to huggingface",
+                    primary=False,
+                    disabled=False,
+                    tooltip=None,
+                ),
+            ]
 
     buttons += [ui.button(name="experiment/list/current", label="Back", primary=False)]
 

--- a/llm_studio/python_configs/cfg_checks.py
+++ b/llm_studio/python_configs/cfg_checks.py
@@ -50,15 +50,6 @@ def check_for_common_errors(cfg: DefaultConfigProblemBase) -> dict:
             "select the GPUs you want to use again. "
         ]
 
-    if cfg.training.save_best_checkpoint and cfg.training.train_validation_data:
-        errors["title"] += ["Save Best Checkpoint incompatible settings."]
-        errors["message"] += [
-            "Save Best Checkpoint is not compatible with "
-            "Train Validation Data. "
-            "Please set Save Best Checkpoint to False or disable "
-            "Train Validation Data. "
-        ]
-
     stats = os.statvfs(".")
     available_size = stats.f_frsize * stats.f_bavail
     if available_size < default_cfg.min_experiment_disk_space:

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -154,7 +154,7 @@ class ConfigNLPCausalLMTraining(DefaultConfig):
     lora_dropout: float = 0.05
     lora_target_modules: str = ""
 
-    save_best_checkpoint: bool = False
+    save_checkpoint: str = "last"
     evaluation_epochs: float = 1.0
     evaluate_before_training: bool = False
     train_validation_data: bool = False
@@ -191,6 +191,15 @@ class ConfigNLPCausalLMTraining(DefaultConfig):
         self._possible_values["lora_alpha"] = (1, 256, 1)
         self._possible_values["lora_dropout"] = (0.0, 0.5, 0.01)
 
+        self._possible_values["save_checkpoint"] = possible_values.String(
+            values=(
+                ("last", "Last"),
+                ("best", "Best"),
+                ("disable", "Disable"),
+            ),
+            allow_custom=False,
+        )
+
         self._possible_values["evaluation_epochs"] = (0.01, 1, 0.01)
 
         self._visibility["loss_class"] = -1
@@ -209,10 +218,6 @@ class ConfigNLPCausalLMTraining(DefaultConfig):
         self._nesting.add(
             ["lora_r", "lora_alpha", "lora_dropout", "lora_target_modules"],
             [Dependency(key="lora", value=False, is_set=False)],
-        )
-        self._nesting.add(
-            ["train_validation_data"],
-            [Dependency(key="save_best_checkpoint", value=False, is_set=True)],
         )
 
 

--- a/tests/integration/test_causal_binary_classification_modeling_cfg.yaml
+++ b/tests/integration/test_causal_binary_classification_modeling_cfg.yaml
@@ -86,7 +86,7 @@ training:
     lora_target_modules: ''
     loss_function: BinaryCrossEntropyLoss
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_binary_classification_modeling_cfg.yaml
+++ b/tests/integration/test_causal_binary_classification_modeling_cfg.yaml
@@ -86,7 +86,7 @@ training:
     lora_target_modules: ''
     loss_function: BinaryCrossEntropyLoss
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_binary_classification_modeling_cpu_cfg.yaml
+++ b/tests/integration/test_causal_binary_classification_modeling_cpu_cfg.yaml
@@ -85,7 +85,7 @@ training:
     lora_target_modules: ''
     loss_function: BinaryCrossEntropyLoss
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_binary_classification_modeling_cpu_cfg.yaml
+++ b/tests/integration/test_causal_binary_classification_modeling_cpu_cfg.yaml
@@ -85,7 +85,7 @@ training:
     lora_target_modules: ''
     loss_function: BinaryCrossEntropyLoss
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_language_modeling_oasst_cfg.yaml
+++ b/tests/integration/test_causal_language_modeling_oasst_cfg.yaml
@@ -93,7 +93,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_language_modeling_oasst_cfg.yaml
+++ b/tests/integration/test_causal_language_modeling_oasst_cfg.yaml
@@ -93,7 +93,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_language_modeling_oasst_cpu_cfg.yaml
+++ b/tests/integration/test_causal_language_modeling_oasst_cpu_cfg.yaml
@@ -92,7 +92,7 @@ training:
   lora_target_modules: ''
   loss_function: TokenAveragedCrossEntropy
   optimizer: AdamW
-  save_checkpoint = "last"
+  save_checkpoint: "last"
   schedule: Cosine
   train_validation_data: false
   warmup_epochs: 0.0

--- a/tests/integration/test_causal_language_modeling_oasst_cpu_cfg.yaml
+++ b/tests/integration/test_causal_language_modeling_oasst_cpu_cfg.yaml
@@ -92,7 +92,7 @@ training:
   lora_target_modules: ''
   loss_function: TokenAveragedCrossEntropy
   optimizer: AdamW
-  save_best_checkpoint: false
+  save_checkpoint = "last"
   schedule: Cosine
   train_validation_data: false
   warmup_epochs: 0.0

--- a/tests/integration/test_causal_multiclass_classification_modeling_cfg.yaml
+++ b/tests/integration/test_causal_multiclass_classification_modeling_cfg.yaml
@@ -86,7 +86,7 @@ training:
     lora_target_modules: ''
     loss_function: CrossEntropyLoss
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_multiclass_classification_modeling_cfg.yaml
+++ b/tests/integration/test_causal_multiclass_classification_modeling_cfg.yaml
@@ -86,7 +86,7 @@ training:
     lora_target_modules: ''
     loss_function: CrossEntropyLoss
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_multiclass_classification_modeling_cpu_cfg.yaml
+++ b/tests/integration/test_causal_multiclass_classification_modeling_cpu_cfg.yaml
@@ -85,7 +85,7 @@ training:
     lora_target_modules: ''
     loss_function: CrossEntropyLoss
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_causal_multiclass_classification_modeling_cpu_cfg.yaml
+++ b/tests/integration/test_causal_multiclass_classification_modeling_cpu_cfg.yaml
@@ -85,7 +85,7 @@ training:
     lora_target_modules: ''
     loss_function: CrossEntropyLoss
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_sequence_to_sequence_modeling_oasst_cfg.yaml
+++ b/tests/integration/test_sequence_to_sequence_modeling_oasst_cfg.yaml
@@ -92,7 +92,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_sequence_to_sequence_modeling_oasst_cfg.yaml
+++ b/tests/integration/test_sequence_to_sequence_modeling_oasst_cfg.yaml
@@ -92,7 +92,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_sequence_to_sequence_modeling_oasst_cpu_cfg.yaml
+++ b/tests/integration/test_sequence_to_sequence_modeling_oasst_cpu_cfg.yaml
@@ -92,7 +92,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/integration/test_sequence_to_sequence_modeling_oasst_cpu_cfg.yaml
+++ b/tests/integration/test_sequence_to_sequence_modeling_oasst_cpu_cfg.yaml
@@ -92,7 +92,7 @@ training:
     lora_target_modules: ''
     loss_function: TokenAveragedCrossEntropy
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/src/test_data/cfg.yaml
+++ b/tests/src/test_data/cfg.yaml
@@ -69,7 +69,7 @@ training:
     lora_r: 4
     lora_target_modules: ''
     optimizer: AdamW
-    save_checkpoint = "last"
+    save_checkpoint: "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/src/test_data/cfg.yaml
+++ b/tests/src/test_data/cfg.yaml
@@ -69,7 +69,7 @@ training:
     lora_r: 4
     lora_target_modules: ''
     optimizer: AdamW
-    save_best_checkpoint: false
+    save_checkpoint = "last"
     schedule: Cosine
     train_validation_data: false
     warmup_epochs: 0.0

--- a/tests/src/utils/test_load_yaml_file.py
+++ b/tests/src/utils/test_load_yaml_file.py
@@ -70,7 +70,7 @@ def test_load_config_yaml():
     assert cfg.training.lora_r == 4
     assert cfg.training.lora_target_modules == ""
     assert cfg.training.optimizer == "AdamW"
-    assert cfg.training.save_best_checkpoint is False
+    assert cfg.training.save_checkpoint == "last"
     assert cfg.training.schedule == "Cosine"
     assert cfg.training.train_validation_data is False
     assert cfg.training.warmup_epochs == 0.0

--- a/train.py
+++ b/train.py
@@ -375,7 +375,7 @@ def run_train(
                     progress_bar.close()
 
                 # TODO: Move back after fixing slow generation of deepspeed.
-                if not cfg.training.save_best_checkpoint:
+                if cfg.training.save_checkpoint == "last":
                     checkpoint_path = cfg.output_directory
                     if cfg.environment._local_rank == 0:
                         logger.info(
@@ -387,7 +387,7 @@ def run_train(
                     cfg=cfg, model=model, val_dataloader=val_dataloader, val_df=val_df
                 )
 
-                if cfg.training.save_best_checkpoint:
+                if cfg.training.save_checkpoint == "best":
                     if objective_op(val_metric, best_val_metric):
                         checkpoint_path = cfg.output_directory
                         if cfg.environment._local_rank == 0:
@@ -606,10 +606,6 @@ def run(cfg: Any) -> None:
             else:
                 model.backbone = torch.compile(model.backbone)
 
-    # Force settings when saving best checkpoint
-    if cfg.training.save_best_checkpoint:
-        cfg.training.train_validation_data = False
-
     # reset steps
     cfg.environment._curr_step = 0
     cfg.environment._curr_val_step = 0
@@ -657,7 +653,7 @@ def run(cfg: Any) -> None:
 
     experiment_path = f"{cfg.output_directory}"
 
-    if cfg.training.epochs == 0:
+    if cfg.training.epochs == 0 and cfg.training.save_checkpoint != "disable":
         checkpoint_path = cfg.output_directory
         if cfg.environment._local_rank == 0:
             logger.info(f"Saving last model checkpoint to {checkpoint_path}")


### PR DESCRIPTION
Removes `save_best_checkpoint` and adds new setting `save_checkpoint` with options:
- last
- best
- disable which will not save checkpoint

additional checks to disable chat, download and pushing of model if checkpoint does not exist

Closes https://github.com/h2oai/h2o-llmstudio/issues/691