### PR TITLE
add config check for learning rate typing

### DIFF
--- a/llm_studio/python_configs/cfg_checks.py
+++ b/llm_studio/python_configs/cfg_checks.py
@@ -102,4 +102,14 @@ def check_for_common_errors(cfg: DefaultConfigProblemBase) -> dict:
             "Deepspeed does not support single GPU training. "
             "Please select more than one GPU or disable deepspeed."
         ]
+
+    # Check if learning rate is accidentally a string
+    # (for example, setting the LR to 3e-4, the yaml considers that a string)
+    if isinstance(cfg.training.learning_rate, str) or isinstance(cfg.training.differential_learning_rate, str):
+        errors["title"] += ["Learning rate in config must be float; e notation is not supported"]
+        errors["message"] += [
+            "Learning rate in config must be float. "
+            "Please convert the learning rate into a purely decimal number."
+        ]
+
     return errors

--- a/llm_studio/python_configs/cfg_checks.py
+++ b/llm_studio/python_configs/cfg_checks.py
@@ -104,12 +104,12 @@ def check_for_common_errors(cfg: DefaultConfigProblemBase) -> dict:
         ]
 
     # Check if learning rate is accidentally a string
-    # (for example, setting the LR to 3e-4, the yaml considers that a string)
+    # (for example, setting the LR to 3e-4, the yaml considers that a string. It must be 3.0e-4 or 3.e-4)
     if isinstance(cfg.training.learning_rate, str) or isinstance(cfg.training.differential_learning_rate, str):
-        errors["title"] += ["Learning rate in config must be float; e notation is not supported"]
+        errors["title"] += ["Learning rate in config must be float; received string"]
         errors["message"] += [
             "Learning rate in config must be float. "
-            "Please convert the learning rate into a purely decimal number."
+            "Please add a decimal point to make it a float (e.g. '3e-4' -> 3.0e-4)"
         ]
 
     return errors

--- a/llm_studio/python_configs/cfg_checks.py
+++ b/llm_studio/python_configs/cfg_checks.py
@@ -104,8 +104,11 @@ def check_for_common_errors(cfg: DefaultConfigProblemBase) -> dict:
         ]
 
     # Check if learning rate is accidentally a string
-    # (for example, setting the LR to 3e-4, the yaml considers that a string. It must be 3.0e-4 or 3.e-4)
-    if isinstance(cfg.training.learning_rate, str) or isinstance(cfg.training.differential_learning_rate, str):
+    # (for example, setting the LR to 3e-4, the yaml considers that a string.
+    # It must be 3.0e-4 or 3.e-4)
+    if isinstance(cfg.training.learning_rate, str) or isinstance(
+        cfg.training.differential_learning_rate, str
+    ):
         errors["title"] += ["Learning rate in config must be float; received string"]
         errors["message"] += [
             "Learning rate in config must be float. "


### PR DESCRIPTION
common error is to set learning rate with e notation. For example 3e-4. Yaml parses it as a string