### PR TITLE
Tokenizer kwargs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,14 @@ test: reports
     -o log_cli=true -o log_level=INFO -o log_file=reports/tests.log \
     tests/* 2>&1 | tee reports/tests.log'
 
+.PHONY: test-custom
+test-custom: reports
+	@bash -c 'set -o pipefail; export PYTHONPATH=$(PWD); \
+	$(PIPENV) run pytest -s -v --junitxml=reports/junit.xml \
+	--import-mode importlib \
+    -o log_cli=true -o log_level=INFO -o log_file=reports/tests.log \
+    tests/src/datasets/test_text_causal_language_modeling_ds.py --tb=no'
+
 .PHONY: test-ui
 test-ui: reports setup-ui
 	@bash -c 'set -o pipefail; \

--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,6 @@ test: reports
     -o log_cli=true -o log_level=INFO -o log_file=reports/tests.log \
     tests/* 2>&1 | tee reports/tests.log'
 
-.PHONY: test-custom
-test-custom: reports
-	@bash -c 'set -o pipefail; export PYTHONPATH=$(PWD); \
-	$(PIPENV) run pytest -s -v --junitxml=reports/junit.xml \
-	--import-mode importlib \
-    -o log_cli=true -o log_level=INFO -o log_file=reports/tests.log \
-    tests/src/datasets/test_text_dpo_modeling_ds.py --tb=no'
-
 .PHONY: test-ui
 test-ui: reports setup-ui
 	@bash -c 'set -o pipefail; \

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test-custom: reports
 	$(PIPENV) run pytest -s -v --junitxml=reports/junit.xml \
 	--import-mode importlib \
     -o log_cli=true -o log_level=INFO -o log_file=reports/tests.log \
-    tests/src/datasets/test_text_causal_language_modeling_ds.py --tb=no'
+    tests/src/datasets/test_text_dpo_modeling_ds.py --tb=no'
 
 .PHONY: test-ui
 test-ui: reports setup-ui

--- a/documentation/docs/get-started/llm-studio-performance.md
+++ b/documentation/docs/get-started/llm-studio-performance.md
@@ -141,7 +141,6 @@ tokenizer:
     max_length_answer: 256
     max_length_prompt: 256
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 2
     differential_learning_rate: 1.0e-05

--- a/documentation/docs/tooltips/experiments/_tokenizer-kwargs.mdx
+++ b/documentation/docs/tooltips/experiments/_tokenizer-kwargs.mdx
@@ -1,0 +1,1 @@
+Custom tokenizer arguments specified as json string. Should be only changed if you know what you are doing in order to adapt to specific use cases or models.

--- a/documentation/docs/tooltips/experiments/_use-fast.mdx
+++ b/documentation/docs/tooltips/experiments/_use-fast.mdx
@@ -1,1 +1,0 @@
-Whether or not to use a Fast tokenizer if possible. Some LLM backbones only offer certain types of tokenizers and changing this setting might be needed.

--- a/examples/example_oasst2.yaml
+++ b/examples/example_oasst2.yaml
@@ -73,7 +73,6 @@ tokenizer:
     max_length_answer: 256
     max_length_prompt: 256
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 2
     differential_learning_rate: 1.0e-05

--- a/llm_studio/app_utils/hugging_face_utils.py
+++ b/llm_studio/app_utils/hugging_face_utils.py
@@ -36,7 +36,6 @@ def get_model_card(cfg, model, repo_id) -> huggingface_hub.ModelCard:
         tags=["gpt", "llm", "large language model", "h2o-llmstudio"],
     )
     cfg_kwargs = dict(
-        use_fast=cfg.tokenizer.use_fast,
         text_prompt_start=cfg.dataset.text_prompt_start,
         text_answer_separator=cfg.dataset.text_answer_separator,
         trust_remote_code=cfg.environment.trust_remote_code,

--- a/llm_studio/app_utils/sections/experiment.py
+++ b/llm_studio/app_utils/sections/experiment.py
@@ -1903,7 +1903,6 @@ def get_experiment_summary_code_card(cfg) -> str:
         text = text.replace(
             "{{max_new_tokens}}", str(cfg.prediction.max_length_inference)
         )
-        text = text.replace("{{use_fast}}", str(cfg.tokenizer.use_fast))
         text = text.replace("{{do_sample}}", str(cfg.prediction.do_sample))
         text = text.replace("{{num_beams}}", str(cfg.prediction.num_beams))
         text = text.replace("{{temperature}}", str(cfg.prediction.temperature))

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -1,4 +1,3 @@
-import json
 import multiprocessing
 import os
 from dataclasses import dataclass, field

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -1,3 +1,4 @@
+import json
 import multiprocessing
 import os
 from dataclasses import dataclass, field
@@ -229,7 +230,7 @@ class ConfigNLPCausalLMTokenizer(DefaultConfig):
     max_length: int = 512
     add_prompt_answer_tokens: bool = False
     padding_quantile: float = 1.0
-    use_fast: bool = True
+    tokenizer_kwargs: str = '{"use_fast": true, "add_prefix_space": false}'
 
     def __post_init__(self):
         super().__post_init__()

--- a/llm_studio/src/datasets/text_causal_language_modeling_ds.py
+++ b/llm_studio/src/datasets/text_causal_language_modeling_ds.py
@@ -27,7 +27,6 @@ class CustomDataset(Dataset):
         self.cfg = cfg
         self.mode = mode
         self.df = df.copy()
-
         self.tokenizer = get_tokenizer(self.cfg)
         self.conversation_chain_handler = ConversationChainHandler(self.df, cfg)
 

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -1,4 +1,5 @@
 import codecs
+import json
 import logging
 import os
 from typing import Any
@@ -34,12 +35,15 @@ def get_texts(df, cfg, separator=None):
 
 
 def get_tokenizer(cfg: Any):
+
+    
     kwargs = dict(
         revision=cfg.environment.huggingface_branch,
-        use_fast=cfg.tokenizer.use_fast,
         trust_remote_code=cfg.environment.trust_remote_code,
         token=os.getenv("HUGGINGFACE_TOKEN"),
     )
+
+    kwargs.update(json.loads(cfg.tokenizer.tokenizer_kwargs.strip()))
 
     try:
         tokenizer = AutoTokenizer.from_pretrained(cfg.llm_backbone, **kwargs)

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -36,7 +36,6 @@ def get_texts(df, cfg, separator=None):
 
 def get_tokenizer(cfg: Any):
 
-    
     kwargs = dict(
         revision=cfg.environment.huggingface_branch,
         trust_remote_code=cfg.environment.trust_remote_code,

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -44,6 +44,14 @@ def get_tokenizer(cfg: Any):
 
     kwargs.update(json.loads(cfg.tokenizer.tokenizer_kwargs.strip()))
 
+    # We will be able to remove this after 
+    # https://github.com/huggingface/transformers/pull/30964
+    tokenizer_class = AutoTokenizer.from_pretrained(cfg.llm_backbone).__class__
+    if tokenizer_class.__name__ in ["LlamaTokenizer", "LlamaTokenizerFast"]:
+        kwargs["from_slow"] = True
+
+    print(kwargs)
+
     try:
         tokenizer = AutoTokenizer.from_pretrained(cfg.llm_backbone, **kwargs)
     except TypeError as e:

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -44,7 +44,7 @@ def get_tokenizer(cfg: Any):
 
     kwargs.update(json.loads(cfg.tokenizer.tokenizer_kwargs.strip()))
 
-    # We will be able to remove this after 
+    # We will be able to remove this after
     # https://github.com/huggingface/transformers/pull/30964
     tokenizer_class = AutoTokenizer.from_pretrained(cfg.llm_backbone).__class__
     if tokenizer_class.__name__ in ["LlamaTokenizer", "LlamaTokenizerFast"]:

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -50,8 +50,6 @@ def get_tokenizer(cfg: Any):
     if tokenizer_class.__name__ in ["LlamaTokenizer", "LlamaTokenizerFast"]:
         kwargs["from_slow"] = True
 
-    print(kwargs)
-
     try:
         tokenizer = AutoTokenizer.from_pretrained(cfg.llm_backbone, **kwargs)
     except TypeError as e:

--- a/model_cards/text_causal_classification_experiment_summary_card_template.md
+++ b/model_cards/text_causal_classification_experiment_summary_card_template.md
@@ -36,7 +36,6 @@ prompt = "{{text_prompt_start}}How are you?{{end_of_sentence}}{{text_answer_sepa
 
 tokenizer = AutoTokenizer.from_pretrained(
     model_name,
-    use_fast={{use_fast}},
     trust_remote_code={{trust_remote_code}},
 )
 model = AutoModelForCausalLM.from_pretrained(

--- a/model_cards/text_causal_classification_model_card_template.md
+++ b/model_cards/text_causal_classification_model_card_template.md
@@ -53,7 +53,6 @@ prompt = "{{text_prompt_start}}How are you?{{end_of_sentence}}{{text_answer_sepa
 
 tokenizer = AutoTokenizer.from_pretrained(
     model_name,
-    use_fast={{use_fast}},
     trust_remote_code={{trust_remote_code}},
 )
 model = AutoModelForCausalLM.from_pretrained(

--- a/model_cards/text_causal_language_modeling_experiment_summary_card_template.md
+++ b/model_cards/text_causal_language_modeling_experiment_summary_card_template.md
@@ -22,7 +22,6 @@ generate_text = pipeline(
     model="{{repo_id}}",
     torch_dtype="auto",
     trust_remote_code=True,
-    use_fast={{use_fast}},
     device_map={"": "cuda:0"},
     token=True,
 )

--- a/model_cards/text_causal_language_modeling_model_card_template.md
+++ b/model_cards/text_causal_language_modeling_model_card_template.md
@@ -43,7 +43,6 @@ generate_text = pipeline(
     model="{{repo_id}}",
     torch_dtype="auto",
     trust_remote_code=True,
-    use_fast={{use_fast}},
     device_map={"": "cuda:0"},
     token=True,
 )
@@ -87,7 +86,6 @@ messages = {{sample_messages}}
 
 tokenizer = AutoTokenizer.from_pretrained(
     model_name,
-    use_fast={{use_fast}},
     trust_remote_code={{trust_remote_code}},
 )
 model = AutoModelForCausalLM.from_pretrained(

--- a/model_cards/text_sequence_to_sequence_modeling_experiment_summary_card_template.md
+++ b/model_cards/text_sequence_to_sequence_modeling_experiment_summary_card_template.md
@@ -20,7 +20,6 @@ prompt = "{{text_prompt_start}}How are you?{{end_of_sentence}}{{text_answer_sepa
 
 tokenizer = AutoTokenizer.from_pretrained(
     model_name,
-    use_fast={{use_fast}},
     trust_remote_code={{trust_remote_code}},
 )
 model = AutoModelForSeq2SeqLM.from_pretrained(

--- a/model_cards/text_sequence_to_sequence_modeling_model_card_template.md
+++ b/model_cards/text_sequence_to_sequence_modeling_model_card_template.md
@@ -39,7 +39,6 @@ prompt = "{{text_prompt_start}}How are you?{{end_of_sentence}}{{text_answer_sepa
 
 tokenizer = AutoTokenizer.from_pretrained(
     model_name,
-    use_fast={{use_fast}},
     trust_remote_code={{trust_remote_code}},
 )
 model = AutoModelForSeq2SeqLM.from_pretrained(

--- a/tests/integration/test_causal_binary_classification_modeling_cfg.yaml
+++ b/tests/integration/test_causal_binary_classification_modeling_cfg.yaml
@@ -66,7 +66,6 @@ tokenizer:
     max_length_answer: 256
     max_length_prompt: 256
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 2
     differential_learning_rate: 1.0e-05

--- a/tests/integration/test_causal_binary_classification_modeling_cpu_cfg.yaml
+++ b/tests/integration/test_causal_binary_classification_modeling_cpu_cfg.yaml
@@ -65,7 +65,6 @@ tokenizer:
     max_length_answer: 16
     max_length_prompt: 16
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 6
     differential_learning_rate: 1.0e-05

--- a/tests/integration/test_causal_language_modeling_oasst_cfg.yaml
+++ b/tests/integration/test_causal_language_modeling_oasst_cfg.yaml
@@ -74,7 +74,6 @@ tokenizer:
     max_length_answer: 256
     max_length_prompt: 256
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 2
     differential_learning_rate: 1.0e-05

--- a/tests/integration/test_causal_language_modeling_oasst_cpu_cfg.yaml
+++ b/tests/integration/test_causal_language_modeling_oasst_cpu_cfg.yaml
@@ -73,7 +73,6 @@ tokenizer:
   max_length_answer: 16
   max_length_prompt: 16
   padding_quantile: 1.0
-  use_fast: true
 training:
   batch_size: 8
   differential_learning_rate: 1.0e-05

--- a/tests/integration/test_causal_multiclass_classification_modeling_cfg.yaml
+++ b/tests/integration/test_causal_multiclass_classification_modeling_cfg.yaml
@@ -66,7 +66,6 @@ tokenizer:
     max_length_answer: 256
     max_length_prompt: 256
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 2
     differential_learning_rate: 1.0e-05

--- a/tests/integration/test_causal_multiclass_classification_modeling_cpu_cfg.yaml
+++ b/tests/integration/test_causal_multiclass_classification_modeling_cpu_cfg.yaml
@@ -65,7 +65,6 @@ tokenizer:
     max_length_answer: 16
     max_length_prompt: 16
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 2
     differential_learning_rate: 1.0e-05

--- a/tests/integration/test_sequence_to_sequence_modeling_oasst_cfg.yaml
+++ b/tests/integration/test_sequence_to_sequence_modeling_oasst_cfg.yaml
@@ -73,7 +73,6 @@ tokenizer:
     max_length_answer: 256
     max_length_prompt: 256
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 2
     differential_learning_rate: 1.0e-05

--- a/tests/integration/test_sequence_to_sequence_modeling_oasst_cpu_cfg.yaml
+++ b/tests/integration/test_sequence_to_sequence_modeling_oasst_cpu_cfg.yaml
@@ -73,7 +73,6 @@ tokenizer:
     max_length_answer: 16
     max_length_prompt: 16
     padding_quantile: 1.0
-    use_fast: true
 training:
     batch_size: 2
     differential_learning_rate: 1.0e-05

--- a/tests/src/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/src/datasets/test_text_causal_language_modeling_ds.py
@@ -312,7 +312,7 @@ def test_encode():
         ),
         tokenizer=ConfigNLPCausalLMTokenizer(
             max_length=64,
-            tokenizer_kwargs='{"use_fast": true, "add_prefix_space": false, "from_slow": true}',
+            tokenizer_kwargs='{"use_fast": true, "add_prefix_space": false}',
         ),
     )
 

--- a/tests/src/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/src/datasets/test_text_causal_language_modeling_ds.py
@@ -310,7 +310,10 @@ def test_encode():
             add_eos_token_to_answer=True,
             limit_chained_samples=True,
         ),
-        tokenizer=ConfigNLPCausalLMTokenizer(max_length=64, tokenizer_kwargs='{"use_fast": true, "add_prefix_space": false, "from_slow": true}'),
+        tokenizer=ConfigNLPCausalLMTokenizer(
+            max_length=64,
+            tokenizer_kwargs='{"use_fast": true, "add_prefix_space": false, "from_slow": true}',
+        ),
     )
 
     cfg.llm_backbone = "h2oai/h2o-danube2-1.8b-base"
@@ -321,4 +324,3 @@ def test_encode():
     result = dataset[0]
     out = dataset.tokenizer.decode(result["input_ids"]).replace("<unk>", "")
     assert out == "<|prompt|>a</s><|answer|>b</s><|prompt|>a</s><|answer|>b</s>"
-

--- a/tests/src/datasets/test_text_causal_language_modeling_ds.py
+++ b/tests/src/datasets/test_text_causal_language_modeling_ds.py
@@ -135,6 +135,8 @@ def test_init(mock_auto_tokenizer):
     cfg.dataset.text_prompt_start = ""
     cfg.dataset.text_answer_separator = ""
 
+    cfg.tokenizer.tokenizer_kwargs = '{"use_fast": true, "add_prefix_space": false}'
+
     dataset = CustomDataset(df, cfg)
 
     assert dataset.df.equals(df)
@@ -286,3 +288,37 @@ def test_getitem_no_chaining():
             f"Prompt:prompt {i+1}"
             "Answer:"
         )
+
+
+def test_encode():
+    df = pd.DataFrame(
+        {
+            "prompt": ["a", "a"],
+            "answer": ["b", "b"],
+            "parent_id": [None, 0],
+            "id": [0, 1],
+        }
+    )
+
+    cfg = ConfigProblemBase(
+        dataset=ConfigNLPCausalLMDataset(
+            prompt_column=("prompt",),
+            answer_column="answer",
+            parent_id_column="parent_id",
+            text_prompt_start="<|prompt|>",
+            text_answer_separator="<|answer|>",
+            add_eos_token_to_answer=True,
+            limit_chained_samples=True,
+        ),
+        tokenizer=ConfigNLPCausalLMTokenizer(max_length=64, tokenizer_kwargs='{"use_fast": true, "add_prefix_space": false, "from_slow": true}'),
+    )
+
+    cfg.llm_backbone = "h2oai/h2o-danube2-1.8b-base"
+
+    dataset = CustomDataset(df, cfg)
+    assert len(dataset) == 1
+
+    result = dataset[0]
+    out = dataset.tokenizer.decode(result["input_ids"]).replace("<unk>", "")
+    assert out == "<|prompt|>a</s><|answer|>b</s><|prompt|>a</s><|answer|>b</s>"
+

--- a/tests/src/datasets/test_text_dpo_modeling_ds.py
+++ b/tests/src/datasets/test_text_dpo_modeling_ds.py
@@ -143,15 +143,15 @@ def test_dataset_label_is_correct(df_with_conversation_chain_ids):
         )
 
         assert (
-            prompt == f"<|prompt|>prompt {idx * 5 + 1} "
-            f"<|answer|> response {idx * 5 + 1} "
-            f"<|prompt|>prompt {idx * 5 + 2} "
-            f"<|answer|> response {idx * 5 + 2} "
-            f"<|prompt|>prompt {idx * 5 + 3} "
-            f"<|answer|> response {idx * 5 + 3} "
-            f"<|prompt|>prompt {idx * 5 + 4} "
-            f"<|answer|> response {idx * 5 + 4} "
-            f"<|prompt|>prompt {idx * 5 + 5} "
+            prompt == f"<|prompt|>prompt {idx * 5 + 1}"
+            f"<|answer|>response {idx * 5 + 1}"
+            f"<|prompt|>prompt {idx * 5 + 2}"
+            f"<|answer|>response {idx * 5 + 2}"
+            f"<|prompt|>prompt {idx * 5 + 3}"
+            f"<|answer|>response {idx * 5 + 3}"
+            f"<|prompt|>prompt {idx * 5 + 4}"
+            f"<|answer|>response {idx * 5 + 4}"
+            f"<|prompt|>prompt {idx * 5 + 5}"
             "<|answer|>"
         )
         assert chosen_response == f"chosen_response {idx * 5 + 5}"


### PR DESCRIPTION
This PR adds a new setting `tokenizer_kwargs` which can be used to set arbitrary tokenizer arguments.

It also effectively reverts https://github.com/h2oai/h2o-llmstudio/pull/650

We need the removal of the prefix token to make it on-par with the chat template. Unfortunately, this does still not work out of the box for Llama tokenizers, but should work after https://github.com/huggingface/transformers/pull/30964.

As soon as https://github.com/huggingface/transformers/pull/30650 is merged, we can consider moving fully to chat templates.