### PR TITLE
Allow to use DPO without LoRA

### DIFF
--- a/llm_studio/python_configs/text_dpo_modeling_config.py
+++ b/llm_studio/python_configs/text_dpo_modeling_config.py
@@ -75,7 +75,6 @@ class ConfigDPOTraining(ConfigNLPCausalLMTraining):
         super().__post_init__()
         self._possible_values["beta"] = possible_values.Number(0.05, 1.0, 0.05)
         self._order.insert("beta", after="learning_rate")
-        self._visibility["lora"] = -1
 
 
 @dataclass

--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -46,7 +46,9 @@ def get_tokenizer(cfg: Any):
 
     # We will be able to remove this after
     # https://github.com/huggingface/transformers/pull/30964
-    tokenizer_class = AutoTokenizer.from_pretrained(cfg.llm_backbone).__class__
+    tokenizer_class = AutoTokenizer.from_pretrained(
+        cfg.llm_backbone, **kwargs
+    ).__class__
     if tokenizer_class.__name__ in ["LlamaTokenizer", "LlamaTokenizerFast"]:
         kwargs["from_slow"] = True
 

--- a/llm_studio/src/utils/data_utils.py
+++ b/llm_studio/src/utils/data_utils.py
@@ -237,6 +237,12 @@ def load_mt_bench_data(cfg: Any) -> pd.DataFrame:
         df[answer_column].fillna("").apply(lambda x: x[0] if x != "" else x)
     )
 
+    if (
+        hasattr(cfg.dataset, "rejected_prompt_column")
+        and cfg.dataset.rejected_prompt_column != "None"
+    ):
+        df[cfg.dataset.rejected_prompt_column] = df[prompt_column]
+
     return df
 
 

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -841,7 +841,9 @@ def create_nlp_backbone(cfg, model_class=AutoModel) -> Any:
                 )
 
     if cfg.architecture.gradient_checkpointing:
-        backbone.gradient_checkpointing_enable()
+        backbone.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={"use_reentrant": False}
+        )
 
     # initialize the generation config
     if backbone.generation_config.eos_token_id != config.eos_token_id:
@@ -1085,7 +1087,9 @@ def generate(backbone, batch, cfg, streamer, remove_prompt=True):
     transformers_logging.set_verbosity(verbosity)
     # enable checkpointing again
     if cfg.architecture.gradient_checkpointing:
-        backbone.gradient_checkpointing_enable()
+        backbone.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={"use_reentrant": False}
+        )
     if remove_prompt:
         output = output[:, input_ids.shape[1] :]
     return output


### PR DESCRIPTION
This PR allows to use DPO without LoRA.

It will require more memory and also keeps a copy of the model in GPU memory.

Additional changes:
- Small fix for getting the tokenizer class
- Fixing `use_reentrant=False` for GC as recommended: https://pytorch.org/docs/stable/checkpoint.html#torch.utils.checkpoint.checkpoint
@pascal-pfeiffer please try re-running your exploding lora dpo runs with this pr and see if there is any change in behavior
This setting is also required for dpo setup without LoRA
- Minor fix for mt-bench data to have a potential rejected prompt column, otherwise fails
