### PR TITLE
fix prompt separator

### DIFF
--- a/llm_studio/app_utils/utils.py
+++ b/llm_studio/app_utils/utils.py
@@ -770,23 +770,6 @@ def get_dataset(
     return dataset, v
 
 
-def escape_python_string(s: str) -> str:
-    """Escapes a python string
-
-    Args:
-        s: string to escape
-
-    Returns:
-        Escaped string
-    """
-
-    s = s.replace("\\", "\\\\")
-    s = s.replace("\n", "\\n")
-    s = s.replace("\t", "\\t")
-    s = s.replace("\r", "\\r")
-    return s
-
-
 def get_ui_element(
     k: str,
     v: Any,
@@ -901,7 +884,7 @@ def get_ui_element(
                 ui.textbox(
                     name=pre + k,
                     label=title_label,
-                    value=escape_python_string(val),
+                    value=val,
                     required=False,
                     password=password,
                     tooltip=tooltip,

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -40,7 +40,7 @@ class ConfigNLPCausalLMDataset(DefaultConfig):
 
     system_column: str = "system"
     prompt_column: Tuple[str, ...] = ("instruction", "input")
-    prompt_column_separator: str = "\n\n"
+    prompt_column_separator: str = "\\n\\n"
     answer_column: str = "output"
     parent_id_column: str = "parent_id"
 


### PR DESCRIPTION
Escaping once in the config does the trick. Now correctly applied from defaults and from custom changes to the default.

closes #772 