### PR TITLE
HF transfer enable

### DIFF
--- a/llm_studio/app_utils/config.py
+++ b/llm_studio/app_utils/config.py
@@ -103,6 +103,9 @@ default_cfg = {
         "default_neptune_project": os.getenv("NEPTUNE_PROJECT", ""),
         "default_neptune_api_token": os.getenv("NEPTUNE_API_TOKEN", ""),
         "default_huggingface_api_token": os.getenv("HUGGINGFACE_TOKEN", ""),
+        "default_hf_hub_enable_hf_transfer": os.getenv(
+            "HF_HUB_ENABLE_HF_TRANSFER", True
+        ),
         "default_openai_azure": os.getenv("OPENAI_API_TYPE", "open_ai") == "azure",
         "default_openai_api_token": os.getenv("OPENAI_API_KEY", ""),
         "default_openai_api_base": os.getenv(

--- a/llm_studio/app_utils/sections/settings.py
+++ b/llm_studio/app_utils/sections/settings.py
@@ -290,7 +290,8 @@ async def settings(q: Q) -> None:
                             "Toggle to enable \
                             <a href='https://github.com/huggingface/hf_transfer' \
                             target='_blank'>HF Transfer</a> for faster \
-                            downloads. EXPERIMENTAL."
+                            downloads. Toggle, if you are experiencing issues on down-\
+                            or upload. EXPERIMENTAL."
                         ),
                         trigger=False,
                     ),

--- a/llm_studio/app_utils/sections/settings.py
+++ b/llm_studio/app_utils/sections/settings.py
@@ -12,7 +12,7 @@ async def settings(q: Q) -> None:
     await clean_dashboard(q, mode="full")
     q.client["nav/active"] = "settings"
 
-    label_width = "250px"
+    label_width = "280px"
     textbox_width = "350px"
 
     q.page["settings/content"] = ui.form_card(
@@ -273,6 +273,26 @@ async def settings(q: Q) -> None:
                         trigger=False,
                         tooltip="Set the value for the Huggingface API token \
                             in the experiment setup.",
+                    ),
+                ]
+            ),
+            ui.inline(
+                items=[
+                    ui.label("Huggingface Hub Enable HF Transfer", width=label_width),
+                    ui.toggle(
+                        name="default_hf_hub_enable_hf_transfer",
+                        value=(
+                            True
+                            if q.client["default_hf_hub_enable_hf_transfer"]
+                            else False
+                        ),
+                        tooltip=(
+                            "Toggle to enable \
+                            <a href='https://github.com/huggingface/hf_transfer' \
+                            target='_blank'>HF Transfer</a> for faster \
+                            downloads. EXPERIMENTAL."
+                        ),
+                        trigger=False,
                     ),
                 ]
             ),

--- a/llm_studio/app_utils/utils.py
+++ b/llm_studio/app_utils/utils.py
@@ -1994,6 +1994,7 @@ def start_experiment(
         "NEPTUNE_API_TOKEN": q.client["default_neptune_api_token"],
         "OPENAI_API_KEY": q.client["default_openai_api_token"],
         "GPT_EVAL_MAX": str(q.client["default_gpt_eval_max"]),
+        "HF_HUB_ENABLE_HF_TRANSFER": str(q.client["default_hf_hub_enable_hf_transfer"]),
     }
     if q.client["default_openai_azure"]:
         env_vars.update(


### PR DESCRIPTION
adds an additional setting to toggle HF Transfer

![image](https://github.com/user-attachments/assets/9ffe4620-322c-44de-bac2-f3d1d1ed389a)

This is an experimental and alternative library to down- and upload to Hugging Face Hub. Toggle, if you are experiencing issues on down- or upload.

fixes #778 for me, if enabled