### PR TITLE
Raise Error if missing system col in train DataFrame

### DIFF
--- a/llm_studio/src/datasets/conversation_chain_handler.py
+++ b/llm_studio/src/datasets/conversation_chain_handler.py
@@ -147,8 +147,8 @@ class ConversationChainHandler:
         if cfg.dataset.system_column != "None":
             if cfg.dataset.system_column not in df.columns:
                 logger.warning(
-                    f"System column {cfg.dataset.system_column} not found."
-                    f"Disabling functionality."
+                    f"System column '{cfg.dataset.system_column}' not found."
+                    " Disabling functionality."
                 )
                 systems = ["" for _ in range(len(self.prompts))]
             else:

--- a/train.py
+++ b/train.py
@@ -532,12 +532,13 @@ def run(cfg: DefaultConfigProblemBase) -> float:
     logger.info("Preparing the data...")
     train_df, val_df = get_data(cfg)
 
-    # We allow system prompt column to be missing in validation DataFrame, but let us assert
-    # that it does exist in the train DataFrame.
+    # We allow system prompt column to be missing in validation DataFrame, but let us
+    # assert that it does exist in the train DataFrame.
     if hasattr(cfg.dataset, "system_column") and cfg.dataset.system_column != "None":
         if cfg.dataset.system_column not in train_df.columns:
             raise LLMTrainingException(
-                f"System column '{cfg.dataset.system_column}' not found in train DataFrame."
+                f"System column '{cfg.dataset.system_column}' not found in train "
+                "DataFrame."
             )
 
     if (

--- a/train.py
+++ b/train.py
@@ -532,6 +532,14 @@ def run(cfg: DefaultConfigProblemBase) -> float:
     logger.info("Preparing the data...")
     train_df, val_df = get_data(cfg)
 
+    # We allow system prompt column to be missing in validation DataFrame, but let us assert
+    # that it does exist in the train DataFrame.
+    if hasattr(cfg.dataset, "system_column") and cfg.dataset.system_column != "None":
+        if cfg.dataset.system_column not in train_df.columns:
+            raise LLMTrainingException(
+                f"System column '{cfg.dataset.system_column}' not found in train DataFrame."
+            )
+
     if (
         len(val_df) > int(os.getenv("GPT_EVAL_MAX", 100))
         and "GPT" in cfg.prediction.metric


### PR DESCRIPTION
I was initially going for DataFrame checks in `check_config_for_errors`, but that overcomplicates the code in a way that I don't feel is necessary for this single check. So, added to `train.py` instead.


```
Traceback (most recent call last):
  File "./h2o-llmstudio/train.py", line 749, in <module>
    run(cfg=cfg)
  File ./h2o-llmstudio/train.py", line 539, in run
    raise LLMTrainingException(
llm_studio.src.utils.exceptions.LLMTrainingException: System column 'i_dont_exist' not found in train DataFrame.
killed
```

closes #600