### PR TITLE
move PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,7 @@ ENV HOME=/home/llmstudio
 # Static application code lives in /workspace/
 WORKDIR /workspace
 
-# Add pip to the PATH
 ENV PATH=/home/llmstudio/.local/bin:$PATH
-ENV PATH=/workspace/.venv/bin:$PATH
 RUN \
     curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10 && \
     chmod -R a+w /home/llmstudio
@@ -42,6 +40,9 @@ COPY Makefile Pipfile Pipfile.lock /workspace/
 # give read and write permissions to the /workspace/.venv/ directory for all users to allow wave to write files
 ENV PIPENV_VENV_IN_PROJECT=1
 RUN make setup && chmod -R 777 /workspace/.venv
+
+# Add the venv to the PATH
+ENV PATH=/workspace/.venv/bin:$PATH
 
 # We need to create a mount point for the user to mount their volume
 # All persistent data lives in /home/llmstudio/mount


### PR DESCRIPTION
Previously, flash-attention installation was failing with:
```
python3.10 -m pipenv run python -m pip install flash-attn==2.6.1 --no-build-isolation --upgrade --no-cache-dir
/workspace/.venv/bin/python3.10: No module named pipenv
```
e.g. https://github.com/h2oai/h2o-llmstudio/actions/runs/10838438509/job/30076644133

It was happening due to mixing the system and venv's Python interpreters. 
We now move adding the venv to PATH after the setup.