### PR TITLE
Cap progress to 0.99 if experiment is still running

### DIFF
--- a/llm_studio/app_utils/utils.py
+++ b/llm_studio/app_utils/utils.py
@@ -1850,6 +1850,9 @@ def get_experiments(
         # make sure progress is 100% for finished experiments
         df.loc[df.status == "finished", "progress"] = "1.0"
 
+        # make sure that if experiment is running the progress is at most 99%
+        df.loc[(df.status == "running") & (pd.to_numeric(df.progress, errors='coerce') > 0.99), "progress"] = ".99"
+
         df["info"] = np.where(
             (df["status"] == "running") & (df["eta"] != ""),
             df["eta"].apply(lambda x: f"ETA: {x}"),

--- a/llm_studio/app_utils/utils.py
+++ b/llm_studio/app_utils/utils.py
@@ -1851,7 +1851,8 @@ def get_experiments(
         df.loc[df.status == "finished", "progress"] = "1.0"
 
         # make sure that if experiment is running the progress is at most 99%
-        df.loc[(df.status == "running") & (pd.to_numeric(df.progress, errors='coerce') > 0.99), "progress"] = ".99"
+        df.loc[(df.status == "running") &
+               (pd.to_numeric(df.progress, errors='coerce') > 0.99), "progress"] = ".99"
 
         df["info"] = np.where(
             (df["status"] == "running") & (df["eta"] != ""),

--- a/llm_studio/app_utils/utils.py
+++ b/llm_studio/app_utils/utils.py
@@ -1851,8 +1851,11 @@ def get_experiments(
         df.loc[df.status == "finished", "progress"] = "1.0"
 
         # make sure that if experiment is running the progress is at most 99%
-        df.loc[(df.status == "running") &
-               (pd.to_numeric(df.progress, errors='coerce') > 0.99), "progress"] = ".99"
+        df.loc[
+            (df.status == "running")
+            & (pd.to_numeric(df.progress, errors="coerce") > 0.99),
+            "progress",
+        ] = ".99"
 
         df["info"] = np.where(
             (df["status"] == "running") & (df["eta"] != ""),


### PR DESCRIPTION
Resolve issue #854  . 
Cap experiment progress to 0.99 in the experiments list window, if the experiment is still running.