### PR TITLE
Change gcloud auth to OIDC

### DIFF
--- a/.github/workflows/build-and-push-nightly.yml
+++ b/.github/workflows/build-and-push-nightly.yml
@@ -11,17 +11,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - id: 'auth'
-        uses: google-github-actions/auth@v2
+      - id: auth
+        uses: google-github-actions/auth@v0.4.0
         with:
-          credentials_json: '${{ secrets.GCP_CRED_JSON }}'
+          workload_identity_provider: 'projects/135982812994/locations/global/workloadIdentityPools/cicd-tooling/providers/github-actions'
+          service_account: 'artifact-rw@vorvan.iam.gserviceaccount.com'
       - name: Configure Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - run: ls -al
       - name: Configure Docker Client
         run: |-
           gcloud auth configure-docker --quiet # authenticate to gcr
-          ls -al
       - name: Clean Docker images
         run: |-
           echo "Available storage before cleaning:"

--- a/.github/workflows/build-and-push-nightly.yml
+++ b/.github/workflows/build-and-push-nightly.yml
@@ -17,9 +17,11 @@ jobs:
           credentials_json: '${{ secrets.GCP_CRED_JSON }}'
       - name: Configure Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
+      - run: ls -al
       - name: Configure Docker Client
         run: |-
-          gcloud auth configure-docker --quiet #authenticate to gcr
+          gcloud auth configure-docker --quiet # authenticate to gcr
+          ls -al
       - name: Clean Docker images
         run: |-
           echo "Available storage before cleaning:"

--- a/.github/workflows/build-and-push-nightly.yml
+++ b/.github/workflows/build-and-push-nightly.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 4 * * *"
   workflow_dispatch:
 
+permissions:
+  id-token: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-push-nightly.yml
+++ b/.github/workflows/build-and-push-nightly.yml
@@ -18,7 +18,7 @@ jobs:
         uses: google-github-actions/auth@v0.4.0
         with:
           workload_identity_provider: 'projects/135982812994/locations/global/workloadIdentityPools/cicd-tooling/providers/github-actions'
-          service_account: 'artifact-rw@vorvan.iam.gserviceaccount.com'
+          service_account: 'gcr-readwrite@vorvan.iam.gserviceaccount.com'
       - name: Configure Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - run: ls -al

--- a/.github/workflows/build-and-push-nightly.yml
+++ b/.github/workflows/build-and-push-nightly.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v0.4.0
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/135982812994/locations/global/workloadIdentityPools/cicd-tooling/providers/github-actions'
           service_account: 'gcr-readwrite@vorvan.iam.gserviceaccount.com'

--- a/.github/workflows/build-and-push-nightly.yml
+++ b/.github/workflows/build-and-push-nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: read
+  id-token: write
 
 jobs:
   build:

--- a/.github/workflows/build-and-push-nightly.yml
+++ b/.github/workflows/build-and-push-nightly.yml
@@ -21,7 +21,6 @@ jobs:
           service_account: 'gcr-readwrite@vorvan.iam.gserviceaccount.com'
       - name: Configure Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
-      - run: ls -al
       - name: Configure Docker Client
         run: |-
           gcloud auth configure-docker --quiet # authenticate to gcr

--- a/.github/workflows/build-and-push-release-gar.yml
+++ b/.github/workflows/build-and-push-release-gar.yml
@@ -6,17 +6,20 @@ on:
       - '**'
   workflow_dispatch:
 
+permissions:
+  id-token: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - id: 'auth'
+      - id: auth
         uses: google-github-actions/auth@v2
         with:
-          project_id: "vorvan"
-          credentials_json: "${{ secrets.GAR_PUSH_CREDENTIALS }}"
+          workload_identity_provider: 'projects/135982812994/locations/global/workloadIdentityPools/cicd-tooling/providers/github-actions'
+          service_account: 'artifact-rw@vorvan.iam.gserviceaccount.com'
       - name: Configure Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure Docker Client

--- a/.github/workflows/build-and-push-release-gcr.yml
+++ b/.github/workflows/build-and-push-release-gcr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v0.4.0
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: 'projects/135982812994/locations/global/workloadIdentityPools/cicd-tooling/providers/github-actions'
           service_account: 'gcr-readwrite@vorvan.iam.gserviceaccount.com'

--- a/.github/workflows/build-and-push-release-gcr.yml
+++ b/.github/workflows/build-and-push-release-gcr.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - '**'
   workflow_dispatch:
+permissions:
+  id-token: write
 
 jobs:
   build:
@@ -12,10 +14,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - id: 'auth'
-        uses: google-github-actions/auth@v2
+      - id: auth
+        uses: google-github-actions/auth@v0.4.0
         with:
-          credentials_json: '${{ secrets.GCP_CRED_JSON }}'
+          workload_identity_provider: 'projects/135982812994/locations/global/workloadIdentityPools/cicd-tooling/providers/github-actions'
+          service_account: 'gcr-readwrite@vorvan.iam.gserviceaccount.com'
       - name: Configure Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
       - name: Configure Docker Client


### PR DESCRIPTION
Previous gcp authenticate method ( with github action library ) save the key into github workspace. Since Dockerfile copy the current directory it copies the key as well. Enabling OIDC removes the dependency of the key file and uses short lives sessions and no key is stored.