### PR TITLE
Add missing ecr login for internal bundle publish and refactor build steps

### DIFF
--- a/.github/workflows/build-and-push-release-bundle.yml
+++ b/.github/workflows/build-and-push-release-bundle.yml
@@ -10,6 +10,8 @@ jobs:
   # Build the Wave bundle once and share it between jobs
   build_bundle:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Minimal permission needed
     outputs:
       version: ${{ steps.extract_version.outputs.version }}
     steps:


### PR DESCRIPTION
* Only run build on tags with `v` prefix
* Add missing ecr login step for internal bundle publish
* Refactor to perform bundle step once and share the artifact between the jobs
* For internal publish, only check out the required Dockerfile instead of the entire repository