### PR TITLE
MD5 Hash for non-cryptographic purposes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ ENV PATH=$CUDA_HOME/bin:$PATH
 ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64
 
 RUN python -m venv /workspace/venv
-ENV PATH="/workspace/venv/bin:$PATH"
 
 # Install uv and python dependencies
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ style: reports uv
 
 .PHONY: format
 format:  # Format and check code with ruff
-	uv tool run ruff format
-	uv tool run ruff check --fix
+	$(UV) tool run ruff format
+	$(UV) tool run ruff check --fix
 
 .PHONY: format-check
 format-check:  # Check format and check code with ruff (fails if changes are needed)

--- a/llm_studio/app_utils/sections/dataset.py
+++ b/llm_studio/app_utils/sections/dataset.py
@@ -1340,7 +1340,9 @@ async def show_summary_tab(q: Q, dataset_id):
 
 
 async def show_statistics_tab(q: Q, dataset_filename, config_filename):
-    cfg_hash = hashlib.md5(open(config_filename, "rb").read()).hexdigest()
+    cfg_hash = hashlib.md5(
+        open(config_filename, "rb").read(), usedforsecurity=False
+    ).hexdigest()
     stats_dict = compute_dataset_statistics(dataset_filename, config_filename, cfg_hash)
 
     for chat_type in ["prompts", "answers"]:

--- a/llm_studio/src/plots/text_causal_language_modeling_plots.py
+++ b/llm_studio/src/plots/text_causal_language_modeling_plots.py
@@ -38,7 +38,7 @@ class Plots:
             + str(cfg.dataset.answer_column)
             + str(cfg.dataset.parent_id_column)
         )
-        config_hash = hashlib.md5(config_id.encode()).hexdigest()
+        config_hash = hashlib.md5(config_id.encode(), usedforsecurity=False).hexdigest()
         path = os.path.join(
             os.path.dirname(cfg.dataset.train_dataframe),
             f"__meta_info__{config_hash}_data_viz.parquet",

--- a/llm_studio/src/plots/text_dpo_modeling_plots.py
+++ b/llm_studio/src/plots/text_dpo_modeling_plots.py
@@ -45,7 +45,7 @@ class Plots:
             + str(cfg.dataset.rejected_answer_column)
             + str(cfg.dataset.parent_id_column)
         )
-        config_hash = hashlib.md5(config_id.encode()).hexdigest()
+        config_hash = hashlib.md5(config_id.encode(), usedforsecurity=False).hexdigest()
         path = os.path.join(
             os.path.dirname(cfg.dataset.train_dataframe),
             f"__meta_info__{config_hash}_data_viz.parquet",


### PR DESCRIPTION
set md5 hash to `usedforsecurity=False`

Tells the OpenSSL/FIPS layer that MD5 is being used for non-cryptographic purposes (cache keys in this case).