### PR TITLE
Refactor: Enforce explicit problem type validation in config loader

### DIFF
--- a/llm_studio/src/utils/config_utils.py
+++ b/llm_studio/src/utils/config_utils.py
@@ -131,6 +131,11 @@ def convert_nested_dictionary_to_cfg_base(
     Inverse operation of convert_cfg_base_to_nested_dictionary
     """
     problem_type = cfg_dict["problem_type"]
+    allowed_types = GENERATION_PROBLEM_TYPES + NON_GENERATION_PROBLEM_TYPES + ["text_sequence_to_sequence_modeling"]
+    
+    if problem_type not in allowed_types:
+        raise NotImplementedError(f"Problem Type {problem_type} not implemented or allowed")
+
     module_name = f"llm_studio.python_configs.{problem_type}_config"
     try:
         module = importlib.import_module(module_name)


### PR DESCRIPTION
This Pull Request addresses the issue of unvalidated dynamic module imports in the configuration loader, as discussed in #972.

The implementation in `llm_studio/src/utils/config_utils.py` currently utilizes the `problem_type` field to dynamically construct module paths for `importlib.import_module`. While the risk of arbitrary code execution is minimal, this pattern can lead to unintended module loading or unexpected runtime behavior.

Validation against the predefined `GENERATION_PROBLEM_TYPES` and `NON_GENERATION_PROBLEM_TYPES` allowlists has been introduced before any module load occurs. This refactor ensures only validated configuration modules are imported, improving the stability of the loader.

**Summary of Changes:**
- Introduced validation logic in `convert_nested_dictionary_to_cfg_base` to check `problem_type` against an allowlist.
- Added `text_sequence_to_sequence_modeling` to the allowlist.
- Raises `NotImplementedError` for unsupported or unvalidated problem types.

Verified the fix with local testing and confirmed `make format` passes.

Closes #972