### PR TITLE
set USER env var in entrypoint to support arbitrary container UIDs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+# Ensure USER is set so that getpass.getuser() works for arbitrary UIDs
+# that may not exist in /etc/passwd (e.g. when running with --user <uid>).
+export USER="${USER:-$(id -un 2>/dev/null)}"
+
 nvidia-smi
 
 echo "Starting H2O LLM Studio..."


### PR DESCRIPTION
`getpass.getuser()` in PyTorch's inductor cache init calls `pwd.getpwuid()` which fails with `KeyError` when the container runs with a UID that has no `/etc/passwd` entry (e.g. --user 955). Setting USER in the entrypoint makes `getpass.getuser()` return early from the env var without hitting pwd.