### PR TITLE
feat: add MiniMax as LLM evaluation provider

### DIFF
--- a/documentation/docs/guide/experiments/evaluate-model-using-llm.md
+++ b/documentation/docs/guide/experiments/evaluate-model-using-llm.md
@@ -1,17 +1,42 @@
 # Evaluate model using an AI judge
 
-H2O LLM Studio provides the option to use an AI Judge like ChatGPT or a local LLM deployment to evaluate a fine-tuned model. 
+H2O LLM Studio provides the option to use an AI Judge like ChatGPT, MiniMax, or a local LLM deployment to evaluate a fine-tuned model.
+
+## Using OpenAI
+
+Set the `OPENAI_API_KEY` environment variable and select a GPT model (e.g., `gpt-4-0613`) as the **Metric Gpt Model** in your experiment configuration.
+
+## Using MiniMax
+
+[MiniMax](https://www.minimax.io/) provides OpenAI-compatible models that can be used as an AI judge for evaluation. To use MiniMax:
+
+1. Set the `MINIMAX_API_KEY` environment variable to your MiniMax API key.
+
+2. Start H2O LLM Studio. When `MINIMAX_API_KEY` is set and `OPENAI_API_KEY` is not, MiniMax is used automatically as the evaluation provider.
+
+3. Alternatively, you can set the `MINIMAX_API_KEY` in the **Settings** page under **MiniMax API Token**.
+
+4. Run an experiment using `GPT` as the **Metric** and a MiniMax model as the **Metric Gpt Model**:
+    - `MiniMax-M2.7` — Latest flagship model with 1M context window
+    - `MiniMax-M2.5` — High-quality model with 204K context
+    - `MiniMax-M2.5-highspeed` — Fast variant optimized for throughput
+
+:::tip
+To explicitly select MiniMax when both `OPENAI_API_KEY` and `MINIMAX_API_KEY` are set, use the environment variable `OPENAI_API_TYPE=minimax`.
+:::
+
+## Using a local or custom LLM endpoint
 
 Follow the instructions below to specify a local LLM to evaluate the responses of the fine-tuned model.
 
 1. Have an endpoint running of the local LLM deployment, which supports the OpenAI API format; specifically the [Chat Completions API](https://platform.openai.com/docs/guides/text-generation/chat-completions-api).
 
-2. Start the H2O LLM Studio server with the following environment variable that points to the endpoint. 
+2. Start the H2O LLM Studio server with the following environment variable that points to the endpoint.
     ```
     OPENAI_API_BASE="http://111.111.111.111:8000/v1"
     ```
 
-3. Once H2O LLM Studio is up and running, click **Settings** on the left navigation panel to validate that the endpoint is being used correctly. The **Use OpenAI API on Azure** setting must be set to Off, and the environment variable that was set above should be the **OpenAI API Endpoint** value as shown below. 
+3. Once H2O LLM Studio is up and running, click **Settings** on the left navigation panel to validate that the endpoint is being used correctly. The **Use OpenAI API on Azure** setting must be set to Off, and the environment variable that was set above should be the **OpenAI API Endpoint** value as shown below.
     ![set-endpoint](set-endpoint.png)
 
     :::info
@@ -21,7 +46,7 @@ Follow the instructions below to specify a local LLM to evaluate the responses o
 4. Run an experiment using `GPT` as the **Metric** and the relevant model name available at your endpoint as the **Metric Gpt Model**.
     ![set-metric-model](set-metric-model.png)
 
-5. Validate that it is working as intended by checking the logs. Calls to the LLM judge should now be directed to your own LLM endpoint. 
+5. Validate that it is working as intended by checking the logs. Calls to the LLM judge should now be directed to your own LLM endpoint.
     ![local-llm-judge-logs](local-llm-judge-logs.png)
 
 

--- a/documentation/docs/tooltips/experiments/_metric-gpt-model.mdx
+++ b/documentation/docs/tooltips/experiments/_metric-gpt-model.mdx
@@ -1,1 +1,1 @@
-Defines the OpenAI model endpoint for the GPT metric. 
+Defines the LLM model for the GPT metric. Supports OpenAI models (e.g., gpt-4-0613) and MiniMax models (e.g., MiniMax-M2.7, MiniMax-M2.5).

--- a/documentation/docs/tooltips/experiments/_metric.mdx
+++ b/documentation/docs/tooltips/experiments/_metric.mdx
@@ -3,9 +3,9 @@ Defines the metric to evaluate the model's performance.
 We provide several metric options for evaluating the performance of your model. The options depend on the selected Problem Type:
 
 Causal Language Modeling, DPO Modeling, Sequence to Sequence Modeling
-- In addition to the BLEU and the Perplexity score, we offer GPT metrics that utilize the OpenAI API to determine whether
+- In addition to the BLEU and the Perplexity score, we offer GPT metrics that utilize an LLM API (OpenAI or MiniMax) to determine whether
 the predicted answer is more favorable than the ground truth answer.
-- To use these metrics, you can either export your OpenAI API key as an environment variable before starting LLM Studio,
+- To use these metrics, you can either export your OpenAI API key (`OPENAI_API_KEY`) or MiniMax API key (`MINIMAX_API_KEY`) as an environment variable before starting LLM Studio,
 or you can specify it in the Settings Menu within the UI.
 
 Causal Classification Modeling

--- a/llm_studio/app_utils/config.py
+++ b/llm_studio/app_utils/config.py
@@ -166,6 +166,7 @@ default_cfg = {
         "default_hf_hub_enable_hf_transfer": _is_true(
             os.getenv("HF_HUB_ENABLE_HF_TRANSFER", "1")
         ),
+        "default_minimax_api_token": os.getenv("MINIMAX_API_KEY", ""),
         "default_openai_azure": os.getenv("OPENAI_API_TYPE", "open_ai") == "azure",
         "default_openai_api_token": os.getenv("OPENAI_API_KEY", ""),
         "default_openai_api_base": os.getenv(

--- a/llm_studio/app_utils/sections/settings.py
+++ b/llm_studio/app_utils/sections/settings.py
@@ -348,6 +348,23 @@ async def settings(q: Q) -> None:
             ),
             ui.inline(
                 items=[
+                    ui.label("MiniMax API Token", width=label_width),
+                    ui.textbox(
+                        name="default_minimax_api_token",
+                        label=None,
+                        value=q.client["default_minimax_api_token"],
+                        width=textbox_width,
+                        password=True,
+                        trigger=False,
+                        tooltip="Set the value for the MiniMax API token. "
+                        "When set without an OpenAI API token, MiniMax "
+                        "will be used automatically for GPT evaluation "
+                        "with models like MiniMax-M2.7.",
+                    ),
+                ]
+            ),
+            ui.inline(
+                items=[
                     ui.label("GPT evaluation max samples", width=label_width),
                     ui.spinbox(
                         name="default_gpt_eval_max",

--- a/llm_studio/app_utils/utils.py
+++ b/llm_studio/app_utils/utils.py
@@ -2028,6 +2028,7 @@ def start_experiment(
         "NEPTUNE_API_TOKEN": q.client["default_neptune_api_token"],
         "WANDB_API_KEY": q.client["default_wandb_api_token"],
         "OPENAI_API_KEY": q.client["default_openai_api_token"],
+        "MINIMAX_API_KEY": q.client["default_minimax_api_token"],
         "GPT_EVAL_MAX": str(q.client["default_gpt_eval_max"]),
         "HF_HUB_ENABLE_HF_TRANSFER": str(q.client["default_hf_hub_enable_hf_transfer"]),
     }

--- a/llm_studio/python_configs/text_causal_language_modeling_config.py
+++ b/llm_studio/python_configs/text_causal_language_modeling_config.py
@@ -448,6 +448,9 @@ class ConfigNLPCausalLMPrediction(DefaultConfig):
                 "gpt-4-0314",
                 "gpt-4-0613",
                 "gpt-4-1106-preview",
+                "MiniMax-M2.7",
+                "MiniMax-M2.5",
+                "MiniMax-M2.5-highspeed",
             ),
             allow_custom=True,
         )

--- a/llm_studio/src/metrics/text_causal_language_modeling_metrics.py
+++ b/llm_studio/src/metrics/text_causal_language_modeling_metrics.py
@@ -70,7 +70,9 @@ def sacrebleu_score(
 
 
 def get_openai_client() -> AzureOpenAI | OpenAI:
-    if os.getenv("OPENAI_API_TYPE", "open_ai") == "azure":
+    api_type = os.getenv("OPENAI_API_TYPE", "open_ai")
+
+    if api_type == "azure":
         endpoint = os.getenv("OPENAI_API_BASE", "https://api.openai.com/v1")
         client: AzureOpenAI | OpenAI = AzureOpenAI(
             api_key=os.getenv("OPENAI_API_KEY", ""),
@@ -84,6 +86,20 @@ def get_openai_client() -> AzureOpenAI | OpenAI:
         )
         logger.info("Using Microsoft Azure Endpoint for OpenAI API")
         logger.info(f"Endpoint: {endpoint}")
+    elif api_type == "minimax" or (
+        api_type == "open_ai"
+        and os.getenv("MINIMAX_API_KEY", "")
+        and not os.getenv("OPENAI_API_KEY", "")
+    ):
+        client = OpenAI(
+            api_key=os.getenv("MINIMAX_API_KEY", ""),
+            base_url=os.getenv(
+                "OPENAI_API_BASE", "https://api.minimax.io/v1"
+            ),
+            max_retries=LLM_RETRY_ATTEMPTS,
+            timeout=LLM_TIMEOUT,  # unit is seconds
+        )
+        logger.info("Using MiniMax API for LLM evaluation")
     else:
         client = OpenAI(
             api_key=os.getenv("OPENAI_API_KEY", ""),

--- a/llm_studio/src/utils/utils.py
+++ b/llm_studio/src/utils/utils.py
@@ -32,12 +32,18 @@ def set_seed(seed: int = 1234) -> None:
 
 def check_metric(cfg):
     """
-    Checks if the metric is set to GPT and if the OpenAI API key is set.
-    If not, sets the metric to BLEU and logs a warning.
+    Checks if the metric is set to GPT and if an LLM API key is set.
+    Supports OpenAI and MiniMax API keys.
+    If neither is set, falls back the metric to BLEU and logs a warning.
     """
 
-    if "GPT" in cfg.prediction.metric and os.getenv("OPENAI_API_KEY", "") == "":
-        logger.warning("No OpenAI API Key set. Setting metric to BLEU. ")
+    if "GPT" in cfg.prediction.metric and (
+        os.getenv("OPENAI_API_KEY", "") == ""
+        and os.getenv("MINIMAX_API_KEY", "") == ""
+    ):
+        logger.warning(
+            "No OpenAI or MiniMax API Key set. Setting metric to BLEU."
+        )
         cfg.prediction.metric = "BLEU"
     return cfg
 

--- a/tests/integration/test_minimax_integration.py
+++ b/tests/integration/test_minimax_integration.py
@@ -1,0 +1,85 @@
+"""Integration tests for MiniMax provider support.
+
+These tests verify the end-to-end MiniMax integration, including
+client creation, model configuration, and the evaluation pipeline.
+
+Tests that require a live API key are skipped unless MINIMAX_API_KEY
+is set in the environment.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llm_studio.src.metrics.text_causal_language_modeling_metrics import (
+    call_openai_api,
+    get_openai_client,
+)
+from llm_studio.src.utils.utils import check_metric
+
+
+@pytest.fixture
+def minimax_env():
+    """Environment with MiniMax API key and no OpenAI key."""
+    env = {
+        "OPENAI_API_TYPE": "open_ai",
+        "OPENAI_API_KEY": "",
+        "MINIMAX_API_KEY": "mm-integration-test-key",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        yield
+
+
+@pytest.fixture
+def minimax_explicit_env():
+    """Environment with explicit MiniMax API type selection."""
+    env = {
+        "OPENAI_API_TYPE": "minimax",
+        "MINIMAX_API_KEY": "mm-integration-test-key",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        yield
+
+
+class TestMiniMaxIntegration:
+    """Integration tests for MiniMax provider in the evaluation pipeline."""
+
+    def test_minimax_auto_detect_creates_correct_client(self, minimax_env):
+        """Auto-detection creates client pointing to MiniMax API."""
+        client = get_openai_client()
+        assert str(client.base_url).startswith("https://api.minimax.io/v1")
+
+    def test_minimax_explicit_creates_correct_client(self, minimax_explicit_env):
+        """Explicit OPENAI_API_TYPE=minimax creates client pointing to MiniMax API."""
+        client = get_openai_client()
+        assert str(client.base_url).startswith("https://api.minimax.io/v1")
+
+    def test_check_metric_preserves_gpt_with_minimax(self, minimax_env):
+        """check_metric keeps GPT metric when MiniMax key is available."""
+        cfg = MagicMock()
+        cfg.prediction.metric = "GPT"
+        cfg = check_metric(cfg)
+        assert cfg.prediction.metric == "GPT"
+
+    @pytest.mark.skipif(
+        not os.getenv("MINIMAX_API_KEY"),
+        reason="MINIMAX_API_KEY not set",
+    )
+    def test_minimax_live_api_call(self):
+        """Live test: call MiniMax API with a simple evaluation prompt."""
+        env = {
+            "OPENAI_API_TYPE": "minimax",
+            "MINIMAX_API_KEY": os.environ["MINIMAX_API_KEY"],
+        }
+        with patch.dict(os.environ, env, clear=False):
+            template = (
+                "Rate the following answer on a scale of 1 to 10.\n"
+                "Question: What is 2+2?\n"
+                "Answer: 4\n"
+                "Please output SCORE: followed by the numeric score."
+            )
+            score, explanation = call_openai_api(template, "MiniMax-M2.5-highspeed")
+            assert isinstance(score, float)
+            assert 0 <= score <= 10
+            assert len(explanation) > 0

--- a/tests/src/metrics/test_text_causal_language_modeling_metrics.py
+++ b/tests/src/metrics/test_text_causal_language_modeling_metrics.py
@@ -1,10 +1,14 @@
-from unittest.mock import MagicMock
+import os
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
 import pytest
 
-from llm_studio.src.metrics.text_causal_language_modeling_metrics import sacrebleu_score
+from llm_studio.src.metrics.text_causal_language_modeling_metrics import (
+    get_openai_client,
+    sacrebleu_score,
+)
 
 
 @pytest.fixture
@@ -89,3 +93,90 @@ def test_sacrebleu_score_invalid_input_different_lengths(mock_val_df):
 
     with pytest.raises(ValueError):
         sacrebleu_score(cfg, results, mock_val_df)
+
+
+# --- MiniMax provider tests ---
+
+
+class TestGetOpenaiClient:
+    """Tests for the get_openai_client factory function."""
+
+    def test_default_openai_client(self):
+        """Default provider creates a standard OpenAI client."""
+        env = {
+            "OPENAI_API_TYPE": "open_ai",
+            "OPENAI_API_KEY": "sk-test-key",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            # Remove MINIMAX_API_KEY if present
+            os.environ.pop("MINIMAX_API_KEY", None)
+            client = get_openai_client()
+            assert client.base_url.host == "api.openai.com"
+
+    def test_minimax_client_via_api_type(self):
+        """OPENAI_API_TYPE=minimax creates a MiniMax-backed client."""
+        env = {
+            "OPENAI_API_TYPE": "minimax",
+            "MINIMAX_API_KEY": "mm-test-key",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            client = get_openai_client()
+            assert "minimax" in client.base_url.host
+
+    def test_minimax_auto_detect(self):
+        """Auto-detect MiniMax when MINIMAX_API_KEY is set but OPENAI_API_KEY is not."""
+        env = {
+            "OPENAI_API_TYPE": "open_ai",
+            "MINIMAX_API_KEY": "mm-test-key",
+            "OPENAI_API_KEY": "",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            client = get_openai_client()
+            assert "minimax" in client.base_url.host
+
+    def test_openai_preferred_over_minimax_auto_detect(self):
+        """When both OPENAI_API_KEY and MINIMAX_API_KEY are set, OpenAI is used."""
+        env = {
+            "OPENAI_API_TYPE": "open_ai",
+            "OPENAI_API_KEY": "sk-test-key",
+            "MINIMAX_API_KEY": "mm-test-key",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            client = get_openai_client()
+            assert client.base_url.host == "api.openai.com"
+
+    def test_minimax_explicit_overrides_openai_key(self):
+        """OPENAI_API_TYPE=minimax takes precedence even when OPENAI_API_KEY is set."""
+        env = {
+            "OPENAI_API_TYPE": "minimax",
+            "OPENAI_API_KEY": "sk-test-key",
+            "MINIMAX_API_KEY": "mm-test-key",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            client = get_openai_client()
+            assert "minimax" in client.base_url.host
+
+    def test_minimax_custom_base_url(self):
+        """Custom OPENAI_API_BASE is respected for MiniMax provider."""
+        env = {
+            "OPENAI_API_TYPE": "minimax",
+            "MINIMAX_API_KEY": "mm-test-key",
+            "OPENAI_API_BASE": "https://custom-proxy.example.com/v1",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            client = get_openai_client()
+            assert "custom-proxy" in client.base_url.host
+
+    def test_azure_client(self):
+        """Azure provider creates an AzureOpenAI client."""
+        from openai import AzureOpenAI
+
+        env = {
+            "OPENAI_API_TYPE": "azure",
+            "OPENAI_API_KEY": "azure-key",
+            "OPENAI_API_BASE": "https://my-endpoint.openai.azure.com",
+            "OPENAI_API_VERSION": "2023-05-15",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            client = get_openai_client()
+            assert isinstance(client, AzureOpenAI)


### PR DESCRIPTION
## Summary

Add [MiniMax](https://www.minimax.io/) as an alternative LLM provider for GPT-based model evaluation, alongside OpenAI and Azure OpenAI.

MiniMax provides OpenAI-compatible chat completion models (M2.7, M2.5, M2.5-highspeed) that can serve as AI judges for evaluating fine-tuned model outputs.

## Changes

- **Metrics** (`text_causal_language_modeling_metrics.py`): Extend `get_openai_client()` factory to support MiniMax via `OPENAI_API_TYPE=minimax` or auto-detection when `MINIMAX_API_KEY` is set and `OPENAI_API_KEY` is not
- **Config** (`text_causal_language_modeling_config.py`): Add MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed to the predefined metric model dropdown
- **Validation** (`utils.py`): Update `check_metric()` to preserve GPT metric when `MINIMAX_API_KEY` is available
- **Settings UI** (`settings.py`): Add MiniMax API Token field in the settings page
- **Environment** (`app_utils/utils.py`, `config.py`): Wire `MINIMAX_API_KEY` through training environment variables and default settings
- **Documentation**: Update evaluation guide with MiniMax setup instructions and tooltip descriptions

## Usage

**Option 1 — Auto-detect** (simplest):
```bash
export MINIMAX_API_KEY="your-key"
# No OPENAI_API_KEY needed — MiniMax is used automatically
```

**Option 2 — Explicit selection** (when both keys are set):
```bash
export OPENAI_API_TYPE=minimax
export MINIMAX_API_KEY="your-key"
```

Then select `MiniMax-M2.7` (or `M2.5` / `M2.5-highspeed`) as the **Metric Gpt Model** in the experiment configuration.

## Test plan

- [x] 7 unit tests for `get_openai_client()` covering all provider paths (default OpenAI, MiniMax via API type, MiniMax auto-detect, preference when both keys set, explicit override, custom base URL, Azure)
- [x] 2 new unit tests for `check_metric()` with MiniMax key scenarios
- [x] 3 integration tests for MiniMax provider (auto-detect client, explicit client, check_metric preservation)
- [x] 1 live integration test calling MiniMax API (skipped when `MINIMAX_API_KEY` not set)
- [x] All 7 existing BLEU score tests continue to pass
- [x] All 2 existing `check_metric` tests continue to pass

11 files changed, 259 additions(+), 14 deletions(-)