### PR TITLE
Replace unmaintained diskcache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ endif
 # Get Trivy from https://aquasecurity.github.io/trivy/v0.53/getting-started/installation/
 .PHONY: trivy-local
 trivy-local: docker-build-nightly
-	trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM --timeout 60m $(DOCKER_IMAGE)
+	trivy image --scanners vuln --severity CRITICAL,HIGH,MEDIUM,LOW --timeout 60m $(DOCKER_IMAGE)
 
 .PHONY: docker-clean-all
 docker-clean-all:

--- a/llm_studio/app_utils/sections/experiment.py
+++ b/llm_studio/app_utils/sections/experiment.py
@@ -19,7 +19,6 @@ import pandas as pd
 import torch
 import transformers
 import yaml
-from diskcache import Cache
 from h2o_wave import Q, data, ui
 
 from llm_studio.app_utils.config import default_cfg
@@ -64,6 +63,7 @@ from llm_studio.src.utils.config_utils import (
     load_config_yaml,
     save_config_yaml,
 )
+from llm_studio.src.utils.disk_kv import Cache
 from llm_studio.src.utils.exceptions import LLMResourceException
 from llm_studio.src.utils.export_utils import (
     check_available_space,

--- a/llm_studio/app_utils/utils.py
+++ b/llm_studio/app_utils/utils.py
@@ -31,7 +31,6 @@ from azure.storage.filedatalake import DataLakeServiceClient
 from boto3.session import Session
 from botocore.handlers import disable_signing
 from datasets import load_dataset
-from diskcache import Cache
 from h2o_wave import Choice, Q, ui
 from pandas.core.frame import DataFrame
 
@@ -45,6 +44,7 @@ from llm_studio.src.utils.config_utils import (
     save_config_yaml,
 )
 from llm_studio.src.utils.data_utils import is_valid_data_frame, read_dataframe
+from llm_studio.src.utils.disk_kv import Cache
 from llm_studio.src.utils.export_utils import get_size_str
 from llm_studio.src.utils.type_annotations import KNOWN_TYPE_ANNOTATIONS
 

--- a/llm_studio/src/loggers.py
+++ b/llm_studio/src/loggers.py
@@ -4,8 +4,8 @@ import os
 from typing import Any
 
 import numpy as np
-from diskcache import Cache
 
+from llm_studio.src.utils.disk_kv import Cache
 from llm_studio.src.utils.plot_utils import PLOT_ENCODINGS
 
 logger = logging.getLogger(__name__)
@@ -79,8 +79,6 @@ class WandbLogger:
 
 class LocalLogger:
     def __init__(self, cfg: Any):
-        logging.getLogger("diskcache").setLevel(logging.ERROR)
-
         self.logs = os.path.join(cfg.output_directory, "charts_cache")
 
         params = get_cfg(cfg)

--- a/llm_studio/src/utils/disk_kv.py
+++ b/llm_studio/src/utils/disk_kv.py
@@ -1,0 +1,119 @@
+"""Tiny persistent key-value store backed by SQLite + pickle.
+
+This module replaces the previously used `diskcache.Cache` for the small
+charts-cache use case. https://github.com/grantjenks/python-diskcache.
+Only the subset of the API actually used by LLM Studio
+is implemented:
+
+    with Cache(directory) as cache:
+        cache[key] = value
+        value = cache[key]
+        if key in cache:
+            ...
+        for key in cache:
+            ...
+        value = cache.get(key, default=None)
+
+Values are pickled, so any picklable Python object can be stored. The store is
+safe for a single writer and concurrent readers across processes (SQLite is
+opened in WAL mode), which matches the original usage pattern: the training
+process writes charts, the app process reads them.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import sqlite3
+from typing import Any, Iterator
+
+DB_FILENAME = "kv.db"
+
+
+class Cache:
+    """Minimal persistent key-value store backed by SQLite.
+
+    Mirrors the small subset of the ``diskcache.Cache`` API used in this
+    project. The cache directory is created on demand. The underlying SQLite
+    database lives at ``<directory>/kv.db``.
+    """
+
+    def __init__(self, directory: str) -> None:
+        self.directory = directory
+        os.makedirs(directory, exist_ok=True)
+        self._db_path = os.path.join(directory, DB_FILENAME)
+        # check_same_thread=False mirrors diskcache, which allowed access from
+        # multiple threads within the same process. Concurrency between
+        # processes is handled by SQLite's WAL mode below.
+        self._conn: sqlite3.Connection | None = sqlite3.connect(
+            self._db_path, check_same_thread=False, timeout=30.0
+        )
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA synchronous=NORMAL")
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS kv ("
+            "  key TEXT PRIMARY KEY,"
+            "  value BLOB NOT NULL"
+            ")"
+        )
+        self._conn.commit()
+
+    # -- context manager ---------------------------------------------------
+    def __enter__(self) -> "Cache":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._conn is not None:
+            try:
+                self._conn.commit()
+            finally:
+                self._conn.close()
+                self._conn = None
+
+    # -- mapping API -------------------------------------------------------
+    def _require_conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise RuntimeError("Cache is closed")
+        return self._conn
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        conn = self._require_conn()
+        blob = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+        conn.execute(
+            "INSERT INTO kv(key, value) VALUES(?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (key, sqlite3.Binary(blob)),
+        )
+        conn.commit()
+
+    def __getitem__(self, key: str) -> Any:
+        conn = self._require_conn()
+        row = conn.execute("SELECT value FROM kv WHERE key = ?", (key,)).fetchone()
+        if row is None:
+            raise KeyError(key)
+        return pickle.loads(row[0])
+
+    def __contains__(self, key: object) -> bool:
+        conn = self._require_conn()
+        row = conn.execute("SELECT 1 FROM kv WHERE key = ?", (key,)).fetchone()
+        return row is not None
+
+    def __iter__(self) -> Iterator[str]:
+        conn = self._require_conn()
+        # Materialize so callers can mutate the cache while iterating.
+        rows = conn.execute("SELECT key FROM kv ORDER BY key").fetchall()
+        return iter(row[0] for row in rows)
+
+    def __len__(self) -> int:
+        conn = self._require_conn()
+        row = conn.execute("SELECT COUNT(*) FROM kv").fetchone()
+        return int(row[0])
+
+    def get(self, key: str, default: Any = None) -> Any:
+        try:
+            return self[key]
+        except KeyError:
+            return default

--- a/llm_studio/src/utils/disk_kv.py
+++ b/llm_studio/src/utils/disk_kv.py
@@ -18,16 +18,32 @@ Values are pickled, so any picklable Python object can be stored. The store is
 safe for a single writer and concurrent readers across processes (SQLite is
 opened in WAL mode), which matches the original usage pattern: the training
 process writes charts, the app process reads them.
+
+The on-disk filename ``cache.db`` is kept identical to the one ``diskcache``
+used, so the cache directory layout stays unchanged across the upgrade. Our
+``kv`` table does not collide with diskcache's ``Cache``/``Settings`` tables.
+If this class opens a database written by the legacy diskcache backend, a
+one-shot migration copies the relevant entries into the new ``kv`` table so
+that charts of pre-upgrade experiments remain readable.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 import pickle
 import sqlite3
+import time
 from typing import Any, Iterator
 
-DB_FILENAME = "kv.db"
+logger = logging.getLogger(__name__)
+
+DB_FILENAME = "cache.db"
+
+# Diskcache value-mode constant for pickled entries (see diskcache/core.py).
+# This is the only mode LLM Studio's LocalLogger ever wrote -- all values
+# were Python dicts, all stored via pickle.
+_DC_MODE_PICKLE = 4
 
 
 class Cache:
@@ -57,6 +73,7 @@ class Cache:
             ")"
         )
         self._conn.commit()
+        self._migrate_legacy_diskcache_if_needed()
 
     # -- context manager ---------------------------------------------------
     def __enter__(self) -> "Cache":
@@ -117,3 +134,118 @@ class Cache:
             return self[key]
         except KeyError:
             return default
+
+    # -- legacy diskcache migration ---------------------------------------
+    # TODO: remove everthing below in v1.16 or later
+    def _migrate_legacy_diskcache_if_needed(self) -> None:
+        """Copy entries from a legacy ``diskcache`` ``Cache`` table into ``kv``.
+
+        Runs on open. No-op if ``kv`` already has any rows or if no legacy
+        ``Cache`` table is present, so it is idempotent and cheap on the hot
+        path. The old table (and any external ``*.val`` files) are left in
+        place to allow rollback to a pre-upgrade version of LLM Studio if
+        ever needed.
+
+        Note on pickle: this code unpickles legacy values. That is acceptable
+        because the cache directory is the same trusted experiment output
+        directory the previous diskcache-based code already unpickled from --
+        we do not introduce any new trust boundary here.
+        """
+        conn = self._require_conn()
+
+        # Already migrated (or fresh-written by this class)?
+        if conn.execute("SELECT 1 FROM kv LIMIT 1").fetchone() is not None:
+            return
+
+        # Legacy table present?
+        has_legacy = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='Cache' LIMIT 1"
+        ).fetchone()
+        if not has_legacy:
+            return
+
+        logger.warning(
+            "Migrating diskcache to new Cache. This will be deprecated in v1.16"
+        )
+
+        try:
+            rows = conn.execute(
+                "SELECT key, raw, mode, filename, value, expire_time FROM Cache"
+            ).fetchall()
+        except sqlite3.Error as exc:
+            logger.warning(
+                "Could not read legacy diskcache table at %s: %s",
+                self._db_path,
+                exc,
+            )
+            return
+
+        now = time.time()
+        migrated = 0
+        skipped = 0
+        for key, raw, mode, filename, value, expire_time in rows:
+            if expire_time is not None and expire_time < now:
+                continue
+            # LLM Studio's LocalLogger only ever wrote (str key, dict value)
+            # entries, so we only migrate raw=1 string keys with MODE_PICKLE
+            # values. Anything else is skipped defensively.
+            if not raw or not isinstance(key, str) or mode != _DC_MODE_PICKLE:
+                skipped += 1
+                continue
+            try:
+                decoded_value = _decode_legacy_pickle_value(
+                    filename, value, self.directory
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Skipping unreadable legacy cache entry %r in %s: %s",
+                    key,
+                    self._db_path,
+                    exc,
+                )
+                skipped += 1
+                continue
+            blob = pickle.dumps(decoded_value, protocol=pickle.HIGHEST_PROTOCOL)
+            conn.execute(
+                "INSERT INTO kv(key, value) VALUES(?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                (key, sqlite3.Binary(blob)),
+            )
+            migrated += 1
+
+        conn.commit()
+        if migrated or skipped:
+            logger.info(
+                "Migrated %d entr%s from legacy diskcache at %s (skipped %d).",
+                migrated,
+                "y" if migrated == 1 else "ies",
+                self._db_path,
+                skipped,
+            )
+
+
+def _decode_legacy_pickle_value(
+    filename: str | None, value: Any, directory: str
+) -> Any:
+    """Decode a ``MODE_PICKLE`` value from a diskcache ``Cache`` row.
+
+    The pickled bytes live either inline in the ``value`` column or in an
+    external ``*.val`` file under the cache directory (diskcache spills
+    values larger than 32 KiB by default).
+    """
+    if filename:
+        full_path = _safe_join(directory, filename)
+        with open(full_path, "rb") as fh:
+            return pickle.load(fh)
+    if isinstance(value, (bytes, memoryview)):
+        return pickle.loads(bytes(value))
+    raise ValueError("MODE_PICKLE row has neither inline blob nor filename")
+
+
+def _safe_join(directory: str, relative: str) -> str:
+    """Resolve ``directory/relative`` and refuse paths that escape ``directory``."""
+    base = os.path.realpath(directory)
+    target = os.path.realpath(os.path.join(base, relative))
+    if not (target == base or target.startswith(base + os.sep)):
+        raise ValueError(f"Refusing to read outside cache directory: {relative!r}")
+    return target

--- a/llm_studio/src/utils/logging_utils.py
+++ b/llm_studio/src/utils/logging_utils.py
@@ -44,9 +44,6 @@ def initialize_logging(cfg: Any | None = None):
         format = "%(asctime)s - %(levelname)s: %(message)s"
     formatter = logging.Formatter(format)
 
-    # Suppress diskcache logs (charts_cache)
-    logging.getLogger("diskcache").setLevel(logging.ERROR)
-
     actual_logger = logging.root
     actual_logger.setLevel(logging.INFO)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "coolname>=2.2.0, <3.0.0",
     "bokeh>=3.5.0, <4.0.0",
     "beautifulsoup4>=4.11.1, <5.0.0",
-    "diskcache==5.6.3",
     "sentencepiece>=0.2.0, <0.3.0",
     "sacrebleu==2.5.1",
     "toml>=0.10.2, <0.11.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,8 +102,6 @@ dill==0.3.9
     #   datasets
     #   h2o-llmstudio
     #   multiprocess
-diskcache==5.6.3
-    # via h2o-llmstudio
 distro==1.9.0
     # via openai
 editor==1.7.0

--- a/tests/src/utils/test_disk_kv.py
+++ b/tests/src/utils/test_disk_kv.py
@@ -1,10 +1,79 @@
 import os
+import pickle
+import sqlite3
 import tempfile
+import time
 
 import numpy as np
 import pytest
 
 from llm_studio.src.utils.disk_kv import DB_FILENAME, Cache
+
+# Diskcache value-mode constants, mirrored from disk_kv._DC_MODE_*.
+_DC_MODE_RAW = 1
+_DC_MODE_BINARY = 2
+_DC_MODE_TEXT = 3
+_DC_MODE_PICKLE = 4
+
+
+def _create_legacy_diskcache_db(directory: str) -> sqlite3.Connection:
+    """Create a minimal diskcache-compatible ``Cache`` table for tests.
+
+    Mirrors the schema in ``diskcache.core`` (only the columns this project
+    actually needs to read).
+    """
+    os.makedirs(directory, exist_ok=True)
+    conn = sqlite3.connect(os.path.join(directory, DB_FILENAME))
+    conn.execute(
+        "CREATE TABLE Cache ("
+        "  rowid INTEGER PRIMARY KEY,"
+        "  key BLOB,"
+        "  raw INTEGER,"
+        "  store_time REAL,"
+        "  expire_time REAL,"
+        "  access_time REAL,"
+        "  access_count INTEGER DEFAULT 0,"
+        "  tag BLOB,"
+        "  size INTEGER DEFAULT 0,"
+        "  mode INTEGER DEFAULT 0,"
+        "  filename TEXT,"
+        "  value BLOB)"
+    )
+    return conn
+
+
+def _insert_legacy_pickle_inline(
+    conn: sqlite3.Connection,
+    key: str,
+    value: object,
+    *,
+    expire_time: float | None = None,
+) -> None:
+    blob = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+    conn.execute(
+        "INSERT INTO Cache(key, raw, mode, filename, value, expire_time) "
+        "VALUES(?, 1, ?, NULL, ?, ?)",
+        (key, _DC_MODE_PICKLE, sqlite3.Binary(blob), expire_time),
+    )
+    conn.commit()
+
+
+def _insert_legacy_pickle_external(
+    conn: sqlite3.Connection,
+    directory: str,
+    key: str,
+    value: object,
+    relative_filename: str,
+) -> None:
+    full_path = os.path.join(directory, relative_filename)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, "wb") as fh:
+        pickle.dump(value, fh, protocol=pickle.HIGHEST_PROTOCOL)
+    conn.execute(
+        "INSERT INTO Cache(key, raw, mode, filename, value) VALUES(?, 1, ?, ?, NULL)",
+        (key, _DC_MODE_PICKLE, relative_filename),
+    )
+    conn.commit()
 
 
 @pytest.fixture
@@ -102,3 +171,84 @@ def test_concurrent_reader_sees_writes(temp_dir):
     finally:
         writer.close()
         reader.close()
+
+
+# -- legacy diskcache migration -------------------------------------------
+def test_migrates_inline_pickle_entries(temp_dir):
+    conn = _create_legacy_diskcache_db(temp_dir)
+    _insert_legacy_pickle_inline(conn, "cfg", {"lr": 1e-4, "epochs": 3})
+    _insert_legacy_pickle_inline(
+        conn, "train", {"loss": {"steps": [1, 2], "values": [0.5, 0.4]}}
+    )
+    _insert_legacy_pickle_inline(conn, "val", {"acc": {"steps": [1], "values": [0.9]}})
+    conn.close()
+
+    with Cache(temp_dir) as cache:
+        assert sorted(cache) == ["cfg", "train", "val"]
+        assert cache["cfg"] == {"lr": 1e-4, "epochs": 3}
+        assert cache["train"] == {"loss": {"steps": [1, 2], "values": [0.5, 0.4]}}
+        assert cache["val"] == {"acc": {"steps": [1], "values": [0.9]}}
+
+
+def test_migrates_external_pickle_files(temp_dir):
+    conn = _create_legacy_diskcache_db(temp_dir)
+    big_value = {"loss": {"steps": list(range(1000)), "values": [0.1] * 1000}}
+    # diskcache stores large values in nested aa/bb/<hex>.val files
+    _insert_legacy_pickle_external(
+        conn, temp_dir, "train", big_value, os.path.join("aa", "bb", "deadbeef.val")
+    )
+    conn.close()
+
+    with Cache(temp_dir) as cache:
+        assert cache["train"] == big_value
+
+
+def test_migration_skips_expired_entries(temp_dir):
+    conn = _create_legacy_diskcache_db(temp_dir)
+    _insert_legacy_pickle_inline(conn, "fresh", {"v": 1})
+    _insert_legacy_pickle_inline(conn, "stale", {"v": 2}, expire_time=time.time() - 10)
+    conn.close()
+
+    with Cache(temp_dir) as cache:
+        assert "fresh" in cache
+        assert "stale" not in cache
+
+
+def test_migration_is_idempotent(temp_dir):
+    conn = _create_legacy_diskcache_db(temp_dir)
+    _insert_legacy_pickle_inline(conn, "k", {"v": 1})
+    conn.close()
+
+    # First open performs migration.
+    with Cache(temp_dir) as cache:
+        assert cache["k"] == {"v": 1}
+        # User updates value via the new code path.
+        cache["k"] = {"v": 2}
+
+    # Re-opening must not re-migrate and overwrite the user's update.
+    with Cache(temp_dir) as cache:
+        assert cache["k"] == {"v": 2}
+
+
+def test_no_migration_when_no_legacy_table(temp_dir):
+    # Fresh open (no legacy data) should not error and should be empty.
+    with Cache(temp_dir) as cache:
+        assert list(cache) == []
+        cache["k"] = 1
+        assert cache["k"] == 1
+
+
+def test_migration_refuses_path_traversal(temp_dir, caplog):
+    conn = _create_legacy_diskcache_db(temp_dir)
+    # Malicious filename pointing outside the cache directory.
+    conn.execute(
+        "INSERT INTO Cache(key, raw, mode, filename, value) VALUES(?, 1, ?, ?, NULL)",
+        ("evil", _DC_MODE_PICKLE, "../../../etc/passwd"),
+    )
+    conn.commit()
+    conn.close()
+
+    with caplog.at_level("WARNING"):
+        with Cache(temp_dir) as cache:
+            assert "evil" not in cache
+    assert any("evil" in rec.message for rec in caplog.records)

--- a/tests/src/utils/test_disk_kv.py
+++ b/tests/src/utils/test_disk_kv.py
@@ -1,0 +1,104 @@
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+from llm_studio.src.utils.disk_kv import DB_FILENAME, Cache
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+def test_set_get(temp_dir):
+    with Cache(temp_dir) as cache:
+        cache["a"] = {"steps": [1, 2], "values": [0.1, 0.2]}
+        assert cache["a"] == {"steps": [1, 2], "values": [0.1, 0.2]}
+
+
+def test_overwrite(temp_dir):
+    with Cache(temp_dir) as cache:
+        cache["a"] = 1
+        cache["a"] = 2
+        assert cache["a"] == 2
+        assert len(cache) == 1
+
+
+def test_contains(temp_dir):
+    with Cache(temp_dir) as cache:
+        cache["a"] = 1
+        assert "a" in cache
+        assert "b" not in cache
+
+
+def test_get_default(temp_dir):
+    with Cache(temp_dir) as cache:
+        assert cache.get("missing") is None
+        assert cache.get("missing", 42) == 42
+        cache["x"] = "value"
+        assert cache.get("x") == "value"
+
+
+def test_keyerror(temp_dir):
+    with Cache(temp_dir) as cache:
+        with pytest.raises(KeyError):
+            _ = cache["nope"]
+
+
+def test_iter_yields_keys(temp_dir):
+    with Cache(temp_dir) as cache:
+        cache["a"] = 1
+        cache["b"] = 2
+        cache["c"] = 3
+        assert sorted(list(cache)) == ["a", "b", "c"]
+        # The pattern used in the codebase: {key: cache.get(key) for key in cache}
+        assert {key: cache.get(key) for key in cache} == {"a": 1, "b": 2, "c": 3}
+
+
+def test_persistence_across_sessions(temp_dir):
+    with Cache(temp_dir) as cache:
+        cache["cfg"] = {"lr": 1e-4, "epochs": 3}
+        cache["train"] = {"loss": {"steps": [1], "values": [0.5]}}
+    # Re-open
+    with Cache(temp_dir) as cache:
+        assert cache["cfg"] == {"lr": 1e-4, "epochs": 3}
+        assert cache["train"] == {"loss": {"steps": [1], "values": [0.5]}}
+
+
+def test_creates_directory(tmp_path):
+    target = tmp_path / "nested" / "charts_cache"
+    with Cache(str(target)) as cache:
+        cache["k"] = 1
+    assert os.path.isfile(target / DB_FILENAME)
+
+
+def test_stores_numpy_floats(temp_dir):
+    # LocalLogger casts to float, but make sure picklable numpy types still work.
+    with Cache(temp_dir) as cache:
+        cache["x"] = float(np.float32(0.25))
+        assert cache["x"] == 0.25
+
+
+def test_use_after_close_raises(temp_dir):
+    cache = Cache(temp_dir)
+    cache["a"] = 1
+    cache.close()
+    with pytest.raises(RuntimeError):
+        _ = cache["a"]
+
+
+def test_concurrent_reader_sees_writes(temp_dir):
+    # Mirrors usage: training process writes, app process reads.
+    writer = Cache(temp_dir)
+    reader = Cache(temp_dir)
+    try:
+        writer["train"] = {"loss": [0.5]}
+        assert reader["train"] == {"loss": [0.5]}
+        writer["train"] = {"loss": [0.5, 0.4]}
+        assert reader["train"] == {"loss": [0.5, 0.4]}
+    finally:
+        writer.close()
+        reader.close()

--- a/uv.lock
+++ b/uv.lock
@@ -567,15 +567,6 @@ wheels = [
 ]
 
 [[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -805,7 +796,6 @@ dependencies = [
     { name = "datasets" },
     { name = "deepspeed" },
     { name = "dill" },
-    { name = "diskcache" },
     { name = "einops" },
     { name = "gputil" },
     { name = "h2o-drive" },
@@ -870,7 +860,6 @@ requires-dist = [
     { name = "datasets", specifier = ">=4.4.1,<5.0.0" },
     { name = "deepspeed", specifier = "==0.17.5" },
     { name = "dill", specifier = ">=0.3.8,<0.4.0" },
-    { name = "diskcache", specifier = "==5.6.3" },
     { name = "einops", specifier = "==0.8.1" },
     { name = "flash-attn", marker = "extra == 'flash'", specifier = "==2.8.3" },
     { name = "gputil", specifier = ">=1.4.0,<2.0.0" },


### PR DESCRIPTION
diskcache is no longer maintained and carries a medium-severity CVE (pickle deserialization RCE if an attacker can write into the cache directory). LLM Studio's cache directory lives under the trusted <cfg.output_directory>/charts_cache/ path, so we are not exposed in practice.

closes #1001