### PR TITLE
ci: use OIDC role secret for OIDC role in workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-session-name: h2o-llmstudio-enterprise-ec2
-          role-to-assume: arn:aws:iam::870498644798:role/GitHub-OIDC-Role
+          role-to-assume: ${{ secrets.GH_OIDC_ROLE_LLM_STUDIO_ENTERPRISE }}
 
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -80,7 +80,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-session-name: h2o-llmstudio-enterprise-ec2
-          role-to-assume: arn:aws:iam::870498644798:role/GitHub-OIDC-Role
+          role-to-assume: ${{ secrets.GH_OIDC_ROLE_LLM_STUDIO_ENTERPRISE }}
       - name: Stop EC2 runner
         uses: machulav/ec2-github-runner@v2.3.8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,3 +88,4 @@ jobs:
           github-token: ${{ secrets.GH_RUNNER_PAT }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,4 +88,3 @@ jobs:
           github-token: ${{ secrets.GH_RUNNER_PAT }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
-          

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-session-name: h2o-llmstudio-ec2
-          role-to-assume: arn:aws:iam::870498644798:role/GitHub-OIDC-Role
+          role-to-assume: ${{ secrets.GH_OIDC_ROLE_LLM_STUDIO_ENTERPRISE }}
 
       - name: Start EC2 runner
         id: start-ec2-runner
@@ -80,7 +80,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-session-name: h2o-llmstudio-ec2
-          role-to-assume: arn:aws:iam::870498644798:role/GitHub-OIDC-Role
+          role-to-assume: ${{ secrets.GH_OIDC_ROLE_LLM_STUDIO_ENTERPRISE }}
       - name: Stop EC2 runner
         uses: machulav/ec2-github-runner@v2.3.8
         with:

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -88,3 +88,4 @@ jobs:
           github-token: ${{ secrets.GH_RUNNER_PAT }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+          

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -87,5 +87,4 @@ jobs:
           mode: stop
           github-token: ${{ secrets.GH_RUNNER_PAT }}
           label: ${{ needs.start-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
-          
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}    

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -87,4 +87,4 @@ jobs:
           mode: stop
           github-token: ${{ secrets.GH_RUNNER_PAT }}
           label: ${{ needs.start-runner.outputs.label }}
-          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}    
+          ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}


### PR DESCRIPTION
## Summary

Replaces the hardcoded AWS OIDC role ARN in the test workflows with the `GH_OIDC_ROLE_LLM_STUDIO_ENTERPRISE` repository secret.

Previously the role was hardcoded in four places. Moving it to a secret avoids leaking the account ID/role in source and lets the role be rotated without code changes.

## Changes

- `.github/workflows/test.yml` — `role-to-assume` in the start-runner and stop-runner jobs now reference `${{ secrets.GH_OIDC_ROLE_LLM_STUDIO_ENTERPRISE }}`
- `.github/workflows/test_ui.yml` — same change in both jobs