### PR TITLE
Fix DeepSpeed 0.17 compatibility (bf16 config + nested autocast)

### DIFF
--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -297,7 +297,6 @@ def get_ds_config(cfg: DefaultConfigProblemBase):
         },
         "bf16": {
             "enabled": True if cfg.architecture.backbone_dtype == "bfloat16" else False,
-            "loss_scale_window": 100,
         },
         # https://www.deepspeed.ai/docs/config-json/#zero-optimizations-for-fp16-training
         "zero_force_ds_cpu_optimizer": False,

--- a/llm_studio/train.py
+++ b/llm_studio/train.py
@@ -278,8 +278,12 @@ def run_train(
             model.require_backward_grad_sync = itr % cfg.training.grad_accumulation == 0
 
             # Forward pass
+            # When using DeepSpeed, mixed precision is handled by the engine via
+            # its bf16/fp16 config, so a nested torch.autocast must not be active
+            # (newer DeepSpeed asserts against it).
             with autocast(
-                enabled=cfg.environment.mixed_precision,
+                enabled=cfg.environment.mixed_precision
+                and not cfg.environment.use_deepspeed,
                 dtype=get_torch_dtype(cfg.environment.mixed_precision_dtype),
             ):
                 output_dict = model.forward(batch)


### PR DESCRIPTION
DeepSpeed 0.17.x validates configs with pydantic (extra='forbid') and asserts against torch.autocast nested outside the engine.

- Remove invalid `loss_scale_window` from the bf16 ds_config block; it is only valid for fp16 (DeepSpeedBF16Config rejects it). Older DeepSpeed silently ignored it.
- Disable the forward-pass torch.autocast wrapper when using DeepSpeed, since the engine handles mixed precision via its bf16/fp16 config. Matches the existing gating in the backward pass and eval loop.

closes #945
