### PR TITLE
ci: use GH_OIDC_ROLE_SHARED_SERVICES_DEV secret for docs OIDC role

### DIFF
--- a/.github/workflows/combined-docs-md-ci.yml
+++ b/.github/workflows/combined-docs-md-ci.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::905418351423:role/Github-OIDC-Role-h2o-llmstudio
+          role-to-assume: ${{ secrets.GH_OIDC_ROLE_SHARED_SERVICES_DEV }}
           role-session-name: h2o-llm-studio
           aws-region: us-east-1
 


### PR DESCRIPTION
## Summary

Replaces the hardcoded AWS OIDC role ARN in the docs CI workflow with the `GH_OIDC_ROLE_SHARED_SERVICES_DEV` repository secret. Keeps the account ID/role out of source and allows the role to be rotated without code changes.