### PR TITLE
Trim redundant CUDA packages from Docker image (15GB -> 8.5GB)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,8 @@ RUN apk update \
     && echo "https://packages.cgr.dev/extras" | tee -a /etc/apk/repositories \
     && apk update \
     && apk add --no-cache \
-    nvidia-cudnn-8 \
-    nvidia-cudnn-8-cuda-${CUDA_MAJOR_VERSION} \
-    nvidia-cudnn-8-cuda-${CUDA_MAJOR_VERSION}-dev \
     nvidia-cuda-cudart-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION} \
-    nvidia-cuda-cudart-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}-dev \
     nvidia-cuda-nvcc-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION} \
-    nvidia-libcublas-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION} \
-    cuda-toolkit-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}-dev \
     make \
     curl \
     git
@@ -47,7 +41,6 @@ ENV PATH=/workspace/.venv/bin:$PATH
 
 # We need to create a mount point for the user to mount their volume
 # All persistent data lives in /mount
-RUN mkdir -p /mount 
 RUN mkdir -p /mount && chown -R nonroot:nonroot /mount
 ENV H2O_LLM_STUDIO_WORKDIR=/mount
 


### PR DESCRIPTION
The torch cu126 wheels bundle their own CUDA libraries (cudnn, cublas, cudart, nvrtc, nvjitlink) into the venv, so the system-level copies installed via apk were redundant. The -dev packages and cuda-toolkit-dev are build-time only and unused (flash-attn, the only thing compiling against CUDA, is not installed in this image).

Removed: nvidia-cudnn-8(+dev), nvidia-libcublas, nvidia-cuda-cudart-dev, cuda-toolkit-dev. Kept nvidia-cuda-nvcc (ptxas) for Triton JIT and the cudart runtime.

Validated on GPU: cuBLAS matmul, cuDNN conv2d, bitsandbytes, Triton JIT, and llm_studio.app import all pass.

Also dropped a duplicate `mkdir -p /mount` layer.