### PR TITLE
ci: use multi-AZ failover for the EC2 test runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3
         with:
           aws-region: us-east-1
           role-session-name: h2o-llmstudio-enterprise-ec2
@@ -27,14 +27,25 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.3.8
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.GH_RUNNER_PAT }}
-          ec2-image-id: ${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}
           ec2-instance-type: ${{ secrets.GH_RUNNER_EC2_INSTANCE_TYPE }}
-          subnet-id: ${{ secrets.GH_RUNNER_SUBNET_ID }}
-          security-group-id: ${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}
+          # Try each AZ in turn until one has capacity. Launching into a single
+          # subnet failed the whole run on InsufficientInstanceCapacity; these are
+          # the same four us-east-1 subnets h2o-llmstudio-enterprise and
+          # hydrogen_torch fall back across. availability-zones-config takes
+          # precedence over ec2-image-id / subnet-id / security-group-id, which
+          # are dropped. All four subnet secrets must be set — an unset one
+          # renders as an empty subnetId and that AZ's launch attempt errors.
+          availability-zones-config: >
+            [
+              {"imageId": "${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}", "subnetId": "${{ secrets.GH_RUNNER_SUBNET_ID }}", "securityGroupId": "${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}"},
+              {"imageId": "${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}", "subnetId": "${{ secrets.GH_RUNNER_SUBNET_ID_2 }}", "securityGroupId": "${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}"},
+              {"imageId": "${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}", "subnetId": "${{ secrets.GH_RUNNER_SUBNET_ID_3 }}", "securityGroupId": "${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}"},
+              {"imageId": "${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}", "subnetId": "${{ secrets.GH_RUNNER_SUBNET_ID_4 }}", "securityGroupId": "${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}"}
+            ]
           aws-resource-tags: >
             [
               {"Key": "h2o/gitHub-repository", "Value": "${{ github.repository }}"},
@@ -76,13 +87,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials for EC2 Runner Management
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3
         with:
           aws-region: us-east-1
           role-session-name: h2o-llmstudio-enterprise-ec2
           role-to-assume: ${{ secrets.GH_OIDC_ROLE_LLM_STUDIO_ENTERPRISE }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.3.8
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.GH_RUNNER_PAT }}

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -19,7 +19,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3
         with:
           aws-region: us-east-1
           role-session-name: h2o-llmstudio-ec2
@@ -27,14 +27,25 @@ jobs:
 
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.3.8
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.GH_RUNNER_PAT }}
-          ec2-image-id: ${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}
           ec2-instance-type: ${{ secrets.GH_RUNNER_EC2_INSTANCE_TYPE }}
-          subnet-id: ${{ secrets.GH_RUNNER_SUBNET_ID }}
-          security-group-id: ${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}
+          # Try each AZ in turn until one has capacity. Launching into a single
+          # subnet failed the whole run on InsufficientInstanceCapacity; these are
+          # the same four us-east-1 subnets h2o-llmstudio-enterprise and
+          # hydrogen_torch fall back across. availability-zones-config takes
+          # precedence over ec2-image-id / subnet-id / security-group-id, which
+          # are dropped. All four subnet secrets must be set — an unset one
+          # renders as an empty subnetId and that AZ's launch attempt errors.
+          availability-zones-config: >
+            [
+              {"imageId": "${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}", "subnetId": "${{ secrets.GH_RUNNER_SUBNET_ID }}", "securityGroupId": "${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}"},
+              {"imageId": "${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}", "subnetId": "${{ secrets.GH_RUNNER_SUBNET_ID_2 }}", "securityGroupId": "${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}"},
+              {"imageId": "${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}", "subnetId": "${{ secrets.GH_RUNNER_SUBNET_ID_3 }}", "securityGroupId": "${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}"},
+              {"imageId": "${{ secrets.GH_RUNNER_EC2_IMAGE_ID }}", "subnetId": "${{ secrets.GH_RUNNER_SUBNET_ID_4 }}", "securityGroupId": "${{ secrets.GH_RUNNER_SECURITY_GROUP_ID }}"}
+            ]
           aws-resource-tags: >
             [
               {"Key": "h2o/gitHub-repository", "Value": "${{ github.repository }}"},
@@ -76,13 +87,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS credentials for EC2 Runner Management
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c  # v6.2.3
         with:
           aws-region: us-east-1
           role-session-name: h2o-llmstudio-ec2
           role-to-assume: ${{ secrets.GH_OIDC_ROLE_LLM_STUDIO_ENTERPRISE }}
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.3.8
+        uses: machulav/ec2-github-runner@343a1b2ae682e681c3cec9a235d882da17ff04ef  # v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.GH_RUNNER_PAT }}


### PR DESCRIPTION
Both the Test and Test-UI workflows launched their self-hosted runner into a single subnet, so an InsufficientInstanceCapacity error in that AZ failed the whole run before a single test executed:

  InsufficientInstanceCapacity: We currently do not have sufficient capacity
  in the Availability Zone you requested (us-east-1b).

Switch to the action's availability-zones-config input, listing the same four us-east-1 subnets h2o-llmstudio-enterprise and hydrogen_torch already fall back across, so the runner retries in the next AZ until one has capacity. availability-zones-config takes precedence over ec2-image-id / subnet-id / security-group-id, which are dropped.

The image, instance type and security group stay behind the existing secrets; three new subnet secrets (GH_RUNNER_SUBNET_ID_2/_3/_4) carry the additional AZs and must be set before this merges.

Bump ec2-github-runner v2.3.8 -> v2.6.1, which is the version that adds availability-zones-config, and configure-aws-credentials v4 -> v6.2.3 to match the pins the other two repos use against the same OIDC role. Both are pinned to the tag's commit SHA.