### PR TITLE
ci: stop building flash-attn in CI, which OOM-killed the runners

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,5 +24,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.10.11
-      - run: make setup-dev
+      # FLASH=0: this runner has no CUDA toolchain, so the flash-attn source
+      # build can only fail here. See the FLASH comment in the Makefile.
+      - run: make setup-dev FLASH=0
       - run: make format-check

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,7 +24,5 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.10.11
-      # FLASH=0: this runner has no CUDA toolchain, so the flash-attn source
-      # build can only fail here. See the FLASH comment in the Makefile.
       - run: make setup-dev FLASH=0
       - run: make format-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,9 @@ jobs:
   test:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
+    # Bounded so a hung job releases the EC2 runner instead of burning the
+    # 6h default.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 
@@ -71,7 +74,10 @@ jobs:
         with:
           python-version: "3.10.11"
       - run: nvidia-smi
-      - run: make setup-dev
+      # FLASH=0: flash-attn has no wheel for torch 2.11+cu130 and its source
+      # build OOM-kills this runner. It is an optional backend the test suite
+      # never exercises. See the FLASH comment in the Makefile.
+      - run: make setup-dev FLASH=0
       - run: make test
 
       # Post-Action Cleanup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,6 @@ jobs:
   test:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
-    # Bounded so a hung job releases the EC2 runner instead of burning the
-    # 6h default.
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
@@ -74,9 +72,6 @@ jobs:
         with:
           python-version: "3.10.11"
       - run: nvidia-smi
-      # FLASH=0: flash-attn has no wheel for torch 2.11+cu130 and its source
-      # build OOM-kills this runner. It is an optional backend the test suite
-      # never exercises. See the FLASH comment in the Makefile.
       - run: make setup-dev FLASH=0
       - run: make test
 

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -58,6 +58,9 @@ jobs:
   test-ui:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
+    # Bounded so a hung job releases the EC2 runner instead of burning the
+    # 6h default; the UI suite itself only trains h2oai/llama2-0b-unit-test.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 
@@ -71,8 +74,11 @@ jobs:
         with:
           python-version: "3.10.11"
       - run: nvidia-smi
-      - run: make setup-dev
-      - run: make test-ui-github-actions
+      # FLASH=0: flash-attn has no wheel for torch 2.11+cu130 and its source
+      # build OOM-kills this runner. It is an optional backend the UI suite
+      # never exercises. See the FLASH comment in the Makefile.
+      - run: make setup-dev FLASH=0
+      - run: make test-ui-github-actions FLASH=0
 
       # Post-Action Cleanup
       - name: Clean workspace after action

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -58,8 +58,6 @@ jobs:
   test-ui:
     needs: start-runner
     runs-on: ${{ needs.start-runner.outputs.label }}
-    # Bounded so a hung job releases the EC2 runner instead of burning the
-    # 6h default; the UI suite itself only trains h2oai/llama2-0b-unit-test.
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
@@ -74,9 +72,6 @@ jobs:
         with:
           python-version: "3.10.11"
       - run: nvidia-smi
-      # FLASH=0: flash-attn has no wheel for torch 2.11+cu130 and its source
-      # build OOM-kills this runner. It is an optional backend the UI suite
-      # never exercises. See the FLASH comment in the Makefile.
       - run: make setup-dev FLASH=0
       - run: make test-ui-github-actions FLASH=0
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,15 @@ else
     PW_DEBUG =
 endif
 
+# flash-attn publishes no wheel for our torch/CUDA pair: 2.8.3's CUDA-13 builds
+# stop at torch 2.10, and we are on 2.11.0+cu130. `--extra flash` therefore always
+# falls back to compiling from source -- 73 nvcc units across four GPU archs
+# (sm_80/90/100/120) -- which OOM-kills CI's 8-vCPU/32GB runner after hours having
+# reached unit 4 of 73. Set FLASH=0 to skip it; CI does. The `-` prefix stays so a
+# failed build is never fatal: flash-attn is an optional runtime attention backend
+# and nothing in the test suite exercises it.
+FLASH ?= 1
+
 .PHONY: uv
 uv:
 	curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -25,12 +34,16 @@ uv:
 .PHONY: setup
 setup: uv  # Install dependencies
 	$(UV) sync --frozen --no-dev
+ifeq ($(FLASH),1)
 	-$(UV) sync --frozen --no-dev --extra flash
+endif
 
 .PHONY: setup-dev
 setup-dev: uv  # Install dependencies including dev dependencies
 	$(UV) sync --frozen --group dev
+ifeq ($(FLASH),1)
 	-$(UV) sync --frozen --group dev --extra flash
+endif
 	$(UV) run playwright install
 
 clean-env:

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,7 @@ else
     PW_DEBUG =
 endif
 
-# flash-attn publishes no wheel for our torch/CUDA pair: 2.8.3's CUDA-13 builds
-# stop at torch 2.10, and we are on 2.11.0+cu130. `--extra flash` therefore always
-# falls back to compiling from source -- 73 nvcc units across four GPU archs
-# (sm_80/90/100/120) -- which OOM-kills CI's 8-vCPU/32GB runner after hours having
-# reached unit 4 of 73. Set FLASH=0 to skip it; CI does. The `-` prefix stays so a
-# failed build is never fatal: flash-attn is an optional runtime attention backend
-# and nothing in the test suite exercises it.
+# flash-attn is an optional runtime attention backend
 FLASH ?= 1
 
 .PHONY: uv


### PR DESCRIPTION
flash-attn 2.8.3 ships CUDA-13 wheels only up to torch 2.10, and the CUDA-13 migration put us on torch 2.11.0+cu130, so `--extra flash` always falls back to a source build.

Gate the extra behind FLASH (default 1, so local installs are unchanged) and pass FLASH=0 in CI. Also cap the two GPU jobs at 90 minutes so a hang releases the EC2 runner.