### PR TITLE
ci: cancel superseded runs on the same ref

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('{0}', github.run_id) || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   style:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('{0}', github.run_id) || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -9,6 +9,10 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('{0}', github.run_id) || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   start-runner:
     name: Start self-hosted EC2 runner


### PR DESCRIPTION
Pushing a new commit to a PR branch left the previous Test and Test-UI runs going, so two GPU runs raced on obsolete code -- each holding its own g5.2xlarge for the duration.

Add the concurrency group hydrogen_torch already uses in test.yml, style.yml, e2e.yml and trivy_scan.yml, so a new commit supersedes the in-flight run on the same ref. workflow_dispatch is keyed on run_id instead, so manual runs get their own group and never cancel one another.

stop-runner is gated on `if: ${{ always() }}`, which holds on cancellation too, so a superseded run still terminates its EC2 instance.

Applied to the three pull_request-triggered workflows. The release and docs workflows are left alone, matching hydrogen_torch, where the equivalents also carry no concurrency group.