### PR TITLE
Drop the unused venv from the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ ENV CUDA_HOME=/usr/local/cuda-${CUDA_MAJOR_VERSION}.${CUDA_MINOR_VERSION}
 ENV PATH=$CUDA_HOME/bin:$PATH
 ENV LD_LIBRARY_PATH=$CUDA_HOME/lib64
 
-RUN python -m venv /workspace/venv
-
 # Install uv and python dependencies
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 RUN --mount=type=bind,src=pyproject.toml,target=pyproject.toml \


### PR DESCRIPTION
`python -m venv /workspace/venv` created a venv nothing ever used. The image runs out of `/workspace/.venv`, which `uv sync` creates and the PATH points at