### PR TITLE
fix: do not send an empty HF_TOKEN as bearer header

### DIFF
--- a/llm_studio/src/datasets/text_utils.py
+++ b/llm_studio/src/datasets/text_utils.py
@@ -142,7 +142,7 @@ def get_tokenizer(cfg: DefaultConfigProblemBase):
     kwargs = dict(
         revision=cfg.environment.huggingface_branch,
         trust_remote_code=cfg.environment.trust_remote_code,
-        token=os.getenv("HF_TOKEN"),
+        token=os.getenv("HF_TOKEN") or None,
     )
 
     kwargs.update(json.loads(cfg.tokenizer.tokenizer_kwargs.strip()))

--- a/llm_studio/src/utils/modeling_utils.py
+++ b/llm_studio/src/utils/modeling_utils.py
@@ -822,14 +822,14 @@ def create_nlp_backbone(cfg: DefaultConfigProblemBase, model_class=AutoModel) ->
     config = AutoConfig.from_pretrained(
         cfg.llm_backbone,
         trust_remote_code=cfg.environment.trust_remote_code,
-        token=os.getenv("HF_TOKEN"),
+        token=os.getenv("HF_TOKEN") or None,
         revision=cfg.environment.huggingface_branch,
         **kwargs,
     )
 
     config = update_backbone_config(config, cfg)
     kwargs = dict()
-    kwargs["token"] = os.getenv("HF_TOKEN")
+    kwargs["token"] = os.getenv("HF_TOKEN") or None
 
     quantization_config = None
     if cfg.architecture.backbone_dtype == "int8" and len(cfg.environment.gpus):


### PR DESCRIPTION
The app stores an unset HuggingFace token as "" and exports it via set_env(HF_TOKEN=...) before loading models. huggingface_hub sends any string token verbatim, so this produced "Authorization: Bearer " which httpx rejects (LocalProtocolError: Illegal header value). transformers 5 now hits the hub API on tokenizer load even for cached models, so model download and chat failed for users without a token configured.